### PR TITLE
Implicit boxing operator from T to Maybe<T>

### DIFF
--- a/Maybe.cs
+++ b/Maybe.cs
@@ -70,6 +70,11 @@ namespace Functional.Maybe
 			return doubleMaybe.HasValue ? doubleMaybe.Value : Nothing;
 		}
 
+	    public static implicit operator Maybe<T>(T source)
+	    {
+	        return source.ToMaybe();
+	    }
+
 		internal Maybe(T value)
 		{
 			_value = value;


### PR DESCRIPTION
I've added implicit boxing operator to Maybe<T> for following reasons:
1) It allows simple collection creation with initializers — 
```C#
var maybesList = new List<Maybe<int>>
            {
                1,
                2,
                3
            };
```
instead of
```C#
var maybesList = new List<Maybe<int>>
            {
                1.ToMaybe(),
                2.ToMaybe(,
                3.ToMaybe(
            };
```
2) possible fix of bad R# hadling of Maybe (don't tested)

But then again, any implicit boxing is evil and possibly performance-striking, so do you have any thoughts on necessity of this feature? E.g. Scala Option type doesn't have implicit boxing out-of-the-box.