### PR TITLE
Add test for WhereValueExist method

### DIFF
--- a/Functional.Maybe.Tests/Functional.Maybe.Tests.csproj
+++ b/Functional.Maybe.Tests/Functional.Maybe.Tests.csproj
@@ -45,13 +45,16 @@
     </When>
     <Otherwise>
       <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework">
+          <Private>False</Private>
+        </Reference>
       </ItemGroup>
     </Otherwise>
   </Choose>
   <ItemGroup>
     <Compile Include="SideEffectsTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="MaybeEnumerableTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Functional.Maybe.csproj">

--- a/Functional.Maybe.Tests/MaybeEnumerableTests.cs
+++ b/Functional.Maybe.Tests/MaybeEnumerableTests.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Linq;
+
+namespace Functional.Maybe.Tests
+{
+    [TestClass]
+    public class MaybeEnumerableTests
+    {
+        [TestMethod]
+        public void WhereValueExist_Should_remove_Nothing_values()
+        {
+            var sequence = new Maybe<int>[] { 1.ToMaybe(), Maybe<int>.Nothing, 2.ToMaybe() };
+            int[] expected = { 1, 2 };
+
+            var actual = sequence.WhereValueExist().ToArray();
+
+            Assert.AreEqual(expected.Length, actual.Length);
+            for (int i = 0; i < expected.Length; i++)
+            {
+                Assert.AreEqual(expected[i], actual[i]);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This method doesn't work. Evidently, there is an infinite loop.

The loop occurs because of a recursive call to the `MaybeEnumerable.Where` extension method.