### PR TITLE
Optimization of FirstMaybe, SingleMaybe, LastMaybe

### DIFF
--- a/Functional.Maybe.Tests/MaybeEnumerableTests.cs
+++ b/Functional.Maybe.Tests/MaybeEnumerableTests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Linq;
 
 namespace Functional.Maybe.Tests
@@ -54,5 +55,123 @@ namespace Functional.Maybe.Tests
 			Assert.AreEqual(3, res.Count());
 			Assert.IsTrue(res.SequenceEqual(new[] { 1, 3, 2 }));
 		}
-	}
+
+        [TestMethod]
+	    public void FirstMaybe_WhenCalledOnEmptyEnumerable_ReturnsNothing()
+        {
+            var maybe = Enumerable.Empty<object>().FirstMaybe();
+
+            Assert.IsTrue(maybe.IsNothing());
+        }
+
+        [TestMethod]
+        public void FirstMaybe_WhenCalledOnEnumerableWithNoMatches_ReturnsNothing()
+        {
+            var collection = new[] { 1, 2 };
+            var itemToSearch = 3;
+
+            var maybe = collection.FirstMaybe(i => i == itemToSearch);
+
+            Assert.IsTrue(maybe.IsNothing());
+        }
+
+        [TestMethod]
+        public void FirstMaybe_WhenCalledOnEnumerableWithMatches_ReturnsFirstMatchingElement()
+        {
+            var expectedItem = Tuple.Create(2);
+            var collection = new[]
+            {
+                Tuple.Create(1),
+                expectedItem,    // first matching element
+                Tuple.Create(2), // last matching element
+                Tuple.Create(3)
+            };
+
+            var maybe = collection.FirstMaybe(i => i.Item1 == 2);
+
+            Assert.IsTrue(maybe.IsSomething());
+            // use AreSame to compare expected value with actual one by reference
+            Assert.AreSame(expectedItem, maybe.Value);
+        }
+
+        [TestMethod]
+	    public void SingleMaybe_WhenCalledOnEmptyEnumerable_ReturnsNothing()
+	    {
+            var maybe = Enumerable.Empty<object>().SingleMaybe();
+
+            Assert.IsTrue(maybe.IsNothing());
+        }
+
+        [TestMethod]
+        public void SingleMaybe_WhenCalledOnEnumerableWithNoMatches_ReturnsNothing()
+        {
+            var collection = new[] { 1, 2 };
+            var itemToSearch = 3;
+
+            var maybe = collection.SingleMaybe(i => i == itemToSearch);
+
+            Assert.IsTrue(maybe.IsNothing());
+        }
+
+        [TestMethod]
+        public void SingleMaybe_WhenCalledOnNonEmptyEnumerableWithMultipleMatches_ReturnsNothing()
+        {
+            var collection = new[] { 1, 1, 2 };
+            var itemToSearch = 1;
+
+            var maybe = collection.SingleMaybe(i => i == itemToSearch);
+
+            Assert.IsTrue(maybe.IsNothing());
+        }
+
+        [TestMethod]
+        public void SingleMaybe_WhenCalledOnNonEmptyEnumerableWithSingleMatch_ReturnsSingleMatchingElement()
+        {
+            var collection = new[] { 1, 2, 3 };
+            var itemToSearch = 2;
+
+            var maybe = collection.SingleMaybe(i => i == itemToSearch);
+
+            Assert.IsTrue(maybe.IsSomething());
+            Assert.AreEqual(itemToSearch, maybe.Value);
+        }
+
+        [TestMethod]
+        public void LastMaybe_WhenCalledOnEmptyEnumerable_ReturnsNothing()
+        {
+            var maybe = Enumerable.Empty<object>().LastMaybe();
+
+            Assert.IsTrue(maybe.IsNothing());
+        }
+
+        [TestMethod]
+        public void LastMaybe_WhenCalledOnEnumerableWithNoMatches_ReturnsNothing()
+        {
+            var collection = new[] { 1, 2 };
+            var itemToSearch = 3;
+
+            var maybe = collection.LastMaybe(i => i == itemToSearch);
+
+            Assert.IsTrue(maybe.IsNothing());
+        }
+
+        [TestMethod]
+        public void LastMaybe_WhenCalledOnEnumerableWithMatches_ReturnsLastMatchingElement()
+        {
+            var expectedItem = Tuple.Create(2);
+            var collection = new[]
+            {
+                Tuple.Create(1),
+                Tuple.Create(2), // first matching element
+                expectedItem,    // last matching element
+                Tuple.Create(3)
+            };
+
+            var maybe = collection.LastMaybe(i => i.Item1 == 2);
+
+            Assert.IsTrue(maybe.IsSomething());
+            // use AreSame to compare expected value with actual one by reference
+            Assert.AreSame(expectedItem, maybe.Value);
+        }
+    }
 }

--- a/MaybeEnumerable.cs
+++ b/MaybeEnumerable.cs
@@ -22,23 +22,27 @@ namespace Functional.Maybe
 			return FirstMaybe(items, arg => true);
 		}
 
-		/// <summary>
-		/// First item matching <paramref name="predicate"/> or Nothing
-		/// </summary>
-		/// <typeparam name="T"></typeparam>
-		/// <param name="items"></param>
-		/// <param name="predicate"></param>
-		/// <returns></returns>
-		public static Maybe<T> FirstMaybe<T>(this IEnumerable<T> items, Func<T, bool> predicate)
-		{
-			Contract.Requires(items != null);
-			Contract.Requires(predicate != null);
+        /// <summary>
+        /// First item matching <paramref name="predicate"/> or Nothing
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="items"></param>
+        /// <param name="predicate"></param>
+        /// <returns></returns>
+        public static Maybe<T> FirstMaybe<T>(this IEnumerable<T> items, Func<T, bool> predicate)
+	    {
+	        Contract.Requires(items != null);
+	        Contract.Requires(predicate != null);
 
-			var filtered = items.Where(predicate).ToArray();
-			return filtered.Any().Then(filtered.First);
-		}
+	        foreach(var item in items) {
+	            if(predicate(item)) {
+	                return item.ToMaybe();
+	            }
+	        }
+	        return Maybe<T>.Nothing;
+	    }
 
-		/// <summary>
+	    /// <summary>
 		/// Single item or Nothing
 		/// </summary>
 		/// <typeparam name="T"></typeparam>
@@ -62,9 +66,22 @@ namespace Functional.Maybe
 			Contract.Requires(items != null);
 			Contract.Requires(predicate != null);
 
-			var all = items.ToArray();
-			return (all.Count(predicate) == 1).Then(() => all.Single(predicate));
-		}
+            var result = default(T);
+            var count = 0;
+            foreach(var element in items) {
+                if(predicate(element)) {
+                    result = element;
+                    count++;
+                    if(count > 1)
+                        return Maybe<T>.Nothing;
+                }
+            }
+            switch(count) {
+                case 0: return Maybe<T>.Nothing;
+                case 1: return result.ToMaybe();
+            }
+            return Maybe<T>.Nothing;
+        }
 
 		/// <summary>
 		/// Last item or Nothing
@@ -78,23 +95,32 @@ namespace Functional.Maybe
 			return LastMaybe(items, arg => true);
 		}
 
-		/// <summary>
-		/// Last item matching <paramref name="predicate"/> or Nothing
-		/// </summary>
-		/// <typeparam name="T"></typeparam>
-		/// <param name="items"></param>
-		/// <param name="predicate"></param>
-		/// <returns></returns>
-		public static Maybe<T> LastMaybe<T>(this IEnumerable<T> items, Func<T, bool> predicate)
-		{
-			Contract.Requires(items != null);
-			Contract.Requires(predicate != null);
-			
-			var filtered = items.Where(predicate).ToArray();
-			return filtered.Any().Then(filtered.Last);
-		}
+	    /// <summary>
+	    /// Last item matching <paramref name="predicate"/> or Nothing
+	    /// </summary>
+	    /// <typeparam name="T"></typeparam>
+	    /// <param name="items"></param>
+	    /// <param name="predicate"></param>
+	    /// <returns></returns>
+	    public static Maybe<T> LastMaybe<T>(this IEnumerable<T> items, Func<T, bool> predicate)
+	    {
+	        Contract.Requires(items != null);
+	        Contract.Requires(predicate != null);
 
-		/// <summary>
+	        var result = default(T);
+	        var found = false;
+	        foreach(var element in items) {
+	            if(predicate(element)) {
+	                result = element;
+	                found = true;
+	            }
+	        }
+	        if(found)
+	            return result.ToMaybe();
+	        return Maybe<T>.Nothing;
+	    }
+
+	    /// <summary>
 		/// Returns the value of <paramref name="maybeCollection"/> if exists orlse an empty collection
 		/// </summary>
 		/// <typeparam name="T"></typeparam>


### PR DESCRIPTION
Removed .ToArray() conversion in the FirstMaybe, SingleMaybe and
LastMaybe methods, added tests for these methods.