### PR TITLE
Add IEnumerable<T> interface

### DIFF
--- a/Functional.Maybe.Tests/Functional.Maybe.Tests.csproj
+++ b/Functional.Maybe.Tests/Functional.Maybe.Tests.csproj
@@ -52,6 +52,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="MaybeEnumeratorTests.cs" />
     <Compile Include="SideEffectsTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="MaybeEnumerableTests.cs" />

--- a/Functional.Maybe.Tests/MaybeEnumeratorTests.cs
+++ b/Functional.Maybe.Tests/MaybeEnumeratorTests.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Functional.Maybe.Tests
+{
+	[TestClass]
+	public class MaybeEnumeratorTests
+	{
+		[TestMethod]
+		public void MaybeWithValueEnumerates()
+		{
+			var m = 1.ToMaybe();
+			int c = 0;
+			foreach (var val in m)
+				c++;
+			foreach (var val in m)
+				c++;
+			Assert.IsTrue(c == 2);
+		}
+
+		[TestMethod]
+		public void EmptyDoesntEnumerate()
+		{
+			bool gotHere = false;
+			foreach (var val in Maybe<bool>.Nothing)
+				gotHere = true;
+			Assert.IsFalse(gotHere);
+		}
+	}
+}

--- a/Maybe.cs
+++ b/Maybe.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Runtime.Serialization;
@@ -26,7 +27,7 @@ namespace Functional.Maybe
 	/// </example>
 	/// <typeparam name="T"></typeparam>
 	[DataContract]
-	public struct Maybe<T> : IEquatable<Maybe<T>>
+	public struct Maybe<T> : IEquatable<Maybe<T>>, IEnumerable<T>
 	{
 		/// <summary>
 		/// Nothing value.
@@ -96,6 +97,22 @@ namespace Functional.Maybe
 			{
 				return (EqualityComparer<T>.Default.GetHashCode(_value)*397) ^ _hasValue.GetHashCode();
 			}
+		}
+
+		private IEnumerable<T> EnumerableValue()
+		{
+			if (HasValue)
+				yield return Value;
+		}
+
+		public IEnumerator<T> GetEnumerator()
+		{
+			return EnumerableValue().GetEnumerator();
+		}
+
+		IEnumerator IEnumerable.GetEnumerator()
+		{
+			return EnumerableValue().GetEnumerator();
 		}
 
 		public static bool operator ==(Maybe<T> left, Maybe<T> right)


### PR DESCRIPTION
Hello, original author here. Nice to see it up on nuget with people using it, I didn't even realize!

Now on to this PR...

---

This adds an IEnumerable<T> interface to Maybe

This allows a potentially more natural way for accessing a value as an alternative to `Do`

For example:

    var mworld = "world".ToMaybe();
    foreach (var world in mworld) {
      Console.WriteLine($"Hello, {world}");
    }

The main motivation is in async scenarios, where dealing with nested lambdas can be kind of awkward.