### PR TITLE
Added `ToMaybeAsync()` for easier conversion from Task<T> to Task<Maybe<T>>

### DIFF
--- a/Functional.Maybe.NTests/MaybeAsyncTests.cs
+++ b/Functional.Maybe.NTests/MaybeAsyncTests.cs
@@ -15,5 +15,19 @@ namespace Functional.Maybe.Tests
 
 			Assert.AreEqual(3, onePlusTwo.Value);
 		}
+
+		[Test]
+		public async Task StructToMaybeAsyncTest()
+		{
+			var task = Task.FromResult(2);
+			Assert.AreEqual((await task).ToMaybe(), await task.ToMaybeAsync());
+		}
+
+		[Test]
+		public async Task ObjectToMaybeAsyncTest()
+		{
+			var task = Task.FromResult("2");
+			Assert.AreEqual((await task).ToMaybe(), await task.ToMaybeAsync());
+		}
 	}
 }

--- a/Functional.Maybe.NTests/MaybeAsyncTests.cs
+++ b/Functional.Maybe.NTests/MaybeAsyncTests.cs
@@ -24,6 +24,13 @@ namespace Functional.Maybe.Tests
 		}
 
 		[Test]
+		public async Task NullableStructToMaybeAsyncTest()
+		{
+			var task = Task.FromResult<int?>(null);
+			Assert.AreEqual((await task).ToMaybe(), await task.ToMaybeAsync());
+		}
+
+		[Test]
 		public async Task ObjectToMaybeAsyncTest()
 		{
 			var task = Task.FromResult("2");

--- a/Functional.Maybe/MaybeAsync.cs
+++ b/Functional.Maybe/MaybeAsync.cs
@@ -14,8 +14,9 @@ namespace Functional.Maybe
 		/// <param name="res">async mapper</param>
 		/// <returns>Task of Maybe of TR</returns>
 		public static async Task<Maybe<TR>> SelectAsync<T, TR>(this Maybe<T> @this, Func<T, Task<TR>> res) => @this.HasValue
-			? (await res(@this.Value)).ToMaybe()
-			: (default);
+			? await res(@this.Value).ToMaybeAsync()
+			: default;
+
 		public static async Task<T> OrElseAsync<T>(this Task<Maybe<T>> @this, Func<Task<T>> orElse)
 		{
 			var res = await @this;
@@ -30,6 +31,10 @@ namespace Functional.Maybe
 		{
 			var res = await @this;
 			return res.HasValue ? res.Value : orElse();
+		} 
+		public static async Task<Maybe<T>> ToMaybeAsync<T>(this Task<T> task)
+		{
+			return (await task).ToMaybe();
 		}
-	}
+  }
 }

--- a/Functional.Maybe/MaybeAsync.cs
+++ b/Functional.Maybe/MaybeAsync.cs
@@ -32,14 +32,9 @@ namespace Functional.Maybe
 			var res = await @this;
 			return res.HasValue ? res.Value : orElse();
 		} 
-		public static async Task<Maybe<T>> ToMaybeAsync<T>(this Task<T> task)
-		{
-			return (await task).ToMaybe();
-		}
-
-		public static async Task<Maybe<T>> ToMaybeAsync<T>(this Task<T?> task) where  T : struct
-		{
-			return (await task).ToMaybe();
-		}
-  }
+		public static async Task<Maybe<T>> ToMaybeAsync<T>(this Task<T> task) => 
+			(await task).ToMaybe();
+		public static async Task<Maybe<T>> ToMaybeAsync<T>(this Task<T?> task) where  T : struct => 
+			(await task).ToMaybe();
+	}
 }

--- a/Functional.Maybe/MaybeAsync.cs
+++ b/Functional.Maybe/MaybeAsync.cs
@@ -36,5 +36,10 @@ namespace Functional.Maybe
 		{
 			return (await task).ToMaybe();
 		}
+
+		public static async Task<Maybe<T>> ToMaybeAsync<T>(this Task<T?> task) where  T : struct
+		{
+			return (await task).ToMaybe();
+		}
   }
 }


### PR DESCRIPTION
When converting from `Task<T>` to `Task<Maybe<T>>` in `async` method, one typically needs to put the  call that returns `Task<T>` together with `await` in parentheses and then call `ToMaybe()` on it:

```csharp
public async Task DoSomething()
{
   await DoSomething((await GetSomething(1,2,3,4)).ToMaybe());
}
```

. The parentheses felt awkward to me since I always had to search for the left one, so I made an extension methods that allows to drop the parentheses. With the `ToMaybeAsync()` extension methods, the above code looks like this:

```csharp
public async Task DoSomething()
{
   await DoSomething(await GetSomething(1,2,3,4).ToMaybeAsync());
}
```

which IMO is more readable as I don't have so many parentheses to visually parse when I am trying to make sense of the code. Hence I created this pull request because I thought maybe others could benefit from it as well.
