### PR TITLE
preliminary implementaton of nullable references support

### DIFF
--- a/Functional.Maybe.NTests/EitherTests.cs
+++ b/Functional.Maybe.NTests/EitherTests.cs
@@ -23,21 +23,21 @@ namespace Functional.Maybe.Tests
        [Test]
         public void NullCheckingTests()
         {
-            Action<int> nullActionInt = null;
+            Action<int>? nullActionInt = null;
 
             void MockActionInt(int x)
             {
                 var y = 5;
             }
 
-            Action<string> nullActionString = null;
+            Action<string>? nullActionString = null;
 
             void MockActionString(string x)
             {
                 var y = 5;
             }
 
-            Action nullAction = null;
+            Action? nullAction = null;
 
             void MockAction()
             {
@@ -45,16 +45,16 @@ namespace Functional.Maybe.Tests
             }
 
             // ReSharper disable ExpressionIsAlwaysNull
-            AssertExtension.Throws<ArgumentNullException>(() => _eitherResult.Match(nullAction, MockAction));
-            AssertExtension.Throws<ArgumentNullException>(() => _eitherResult.Match(MockAction, nullAction));
+            AssertExtension.Throws<ArgumentNullException>(() => _eitherResult.Match(nullAction!, MockAction));
+            AssertExtension.Throws<ArgumentNullException>(() => _eitherResult.Match(MockAction, nullAction!));
             _eitherResult.Match(MockAction, MockAction);
 
-            AssertExtension.Throws<ArgumentNullException>(() => _eitherError.Match(nullAction, MockAction));
-            AssertExtension.Throws<ArgumentNullException>(() => _eitherError.Match(MockAction, nullAction));
+            AssertExtension.Throws<ArgumentNullException>(() => _eitherError.Match(nullAction!, MockAction));
+            AssertExtension.Throws<ArgumentNullException>(() => _eitherError.Match(MockAction, nullAction!));
             _eitherError.Match(MockAction, MockAction);
 
-            AssertExtension.Throws<ArgumentNullException>(() => _eitherError.Match(nullActionInt, MockActionString));
-            AssertExtension.Throws<ArgumentNullException>(() => _eitherError.Match(MockActionInt, nullActionString));
+            AssertExtension.Throws<ArgumentNullException>(() => _eitherError.Match(nullActionInt!, MockActionString));
+            AssertExtension.Throws<ArgumentNullException>(() => _eitherError.Match(MockActionInt, nullActionString!));
             _eitherResult.Match(MockActionInt, MockActionString);
         }
 

--- a/Functional.Maybe.NTests/Functional.Maybe.NTests.csproj
+++ b/Functional.Maybe.NTests/Functional.Maybe.NTests.csproj
@@ -1,12 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netcoreapp2.2</TargetFramework>
+		<TargetFramework>net5.0</TargetFramework>
 
 		<IsPackable>false</IsPackable>
 
 		<LangVersion>latest</LangVersion>
-	</PropertyGroup>
+    <Nullable>enable</Nullable>
+    <WarningsAsErrors>nullable</WarningsAsErrors>
+  </PropertyGroup>
 
 	<ItemGroup>
 		<PackageReference Include="nunit" Version="3.11.0" />

--- a/Functional.Maybe.NTests/MaybeAsyncTests.cs
+++ b/Functional.Maybe.NTests/MaybeAsyncTests.cs
@@ -15,5 +15,39 @@ namespace Functional.Maybe.Tests
 
 			Assert.AreEqual(3, onePlusTwo.Value);
 		}
+
+		[Test]
+		public async Task SelectAsyncWithTransformationReturningNullTest()
+		{
+			Task<string?> GetNull() => Task.FromResult<string?>(null);
+
+			var result = await "a".ToMaybe().SelectAsync(async _ => await GetNull());
+
+			Assert.AreEqual(Maybe<string>.Nothing, result);
+		}
+
+		[Test]
+		public async Task MatchAsyncWithValueTransformationReturningNullTest()
+		{
+			Task<string?> GetNull() => Task.FromResult<string?>(null);
+
+			var result = await "a".ToMaybe().MatchAsync(
+				async _ => await GetNull(),
+				async () => await GetNull());
+
+			Assert.IsNull(result);
+		}
+
+		[Test]
+		public async Task MatchAsyncWithAlternativeFunctionReturningNullTest()
+		{
+			Task<string?> GetNull() => Task.FromResult<string?>(null);
+
+			var result = await Maybe<string>.Nothing.MatchAsync(
+				async _ => await GetNull(),
+				async () => await GetNull());
+
+			Assert.IsNull(result);
+		}
 	}
 }

--- a/Functional.Maybe.NTests/MaybeCannotContainNull.cs
+++ b/Functional.Maybe.NTests/MaybeCannotContainNull.cs
@@ -8,7 +8,7 @@ namespace Functional.Maybe.Tests
 	{
 		private class User
 		{
-			public string Name { get; set; }
+			public string? Name { get; set; }
 		}
 
 		[Test]

--- a/Functional.Maybe.NTests/MaybeEnumerableTests.cs
+++ b/Functional.Maybe.NTests/MaybeEnumerableTests.cs
@@ -10,7 +10,7 @@ namespace Functional.Maybe.Tests
 		[Test]
 		public void WhereValueExist_Should_remove_Nothing_values()
 		{
-			var sequence = new Maybe<int>[] { 1.ToMaybe(), Maybe<int>.Nothing, 2.ToMaybe() };
+			var sequence = new[] { 1.ToMaybe(), Maybe<int>.Nothing, 2.ToMaybe() };
 			int[] expected = { 1, 2 };
 
 			var actual = sequence.WhereValueExist().ToArray();
@@ -23,6 +23,17 @@ namespace Functional.Maybe.Tests
 		}
 
 		[Test]
+		public void SelectWhereValueExist_Should_work_with_null_returned_from_transformation()
+		{
+			var sequence = new[] { "a".ToMaybe(), "b".ToMaybe(), "c".ToMaybe() };
+			var expected = new string?[] { null, null, null };
+
+			string?[] actual = sequence.SelectWhereValueExist<string, string?>(s => null).ToArray();
+
+			CollectionAssert.AreEqual(expected, actual);
+		}
+
+		[Test]
 		public void Given_ThreeSome_UnionReturnsCollectionOfAll()
 		{
 			var one = 1.ToMaybe();
@@ -32,6 +43,21 @@ namespace Functional.Maybe.Tests
 			var res = one.Union(two, three);
 			Assert.AreEqual(3, res.Count());
 			Assert.IsTrue(res.SequenceEqual(new[] { 1, 2, 3 }));
+		}
+
+		[Test]
+		public void Given_EnumerableOfMaybes_SelectShouldWorkWithNullValues()
+		{
+			var enumerable = new[] { "a".ToMaybe(), "b".ToMaybe(), "c".ToMaybe() };
+
+			var results = enumerable.Select<string, string>(s => null);
+
+			CollectionAssert.AreEqual(new []
+			{
+				Maybe<string>.Nothing,
+				Maybe<string>.Nothing,
+				Maybe<string>.Nothing,
+			}, results);
 		}
 
 		[Test]
@@ -56,7 +82,7 @@ namespace Functional.Maybe.Tests
 			Assert.IsTrue(res.SequenceEqual(new[] { 1, 3, 2 }));
 		}
 
-       [Test]
+      [Test]
 	    public void FirstMaybe_WhenCalledOnEmptyEnumerable_ReturnsNothing()
         {
             var maybe = Enumerable.Empty<object>().FirstMaybe();

--- a/Functional.Maybe.NTests/MaybeLinqTests.cs
+++ b/Functional.Maybe.NTests/MaybeLinqTests.cs
@@ -1,0 +1,41 @@
+﻿using NUnit.Framework;
+
+namespace Functional.Maybe.NTests
+{
+	class MaybeLinqTests
+	{
+		[Test]
+		public void SelectOrElseWithConversionToNullableTest()
+		{
+			Maybe<string> maybeString = Maybe<string>.Nothing;
+
+			var alternativeValue = maybeString.SelectOrElse<string, string?>(s => s, () => null);
+
+			Assert.IsNull(alternativeValue);
+		}
+
+		[Test]
+		public void SelectMaybeWithTransformationReturningNullTest()
+		{
+			var maybeString = "a".ToMaybe();
+
+			var result = maybeString.SelectMaybe<string, string, string>(
+				s => s.ToMaybe(), 
+				(s, s1) => null);
+				
+			Assert.AreEqual(Maybe<string>.Nothing, result);
+		}
+
+		[Test]
+		public void SelectManyWithTransformationReturningNullTest()
+		{
+			var maybeString = "a".ToMaybe();
+
+			var result = maybeString.SelectMany<string, string, string>(
+				s => s.ToMaybe(), 
+				(s, s1) => null);
+				
+			Assert.AreEqual(Maybe<string>.Nothing, result);
+		}
+	}
+}

--- a/Functional.Maybe/Either.cs
+++ b/Functional.Maybe/Either.cs
@@ -9,11 +9,11 @@ namespace Functional.Either
     /// </summary>
     public readonly struct Either<TResult, TError>
     {
-        private readonly TResult _resultValue;
-        private readonly TError _errorValue;
+        private readonly TResult? _resultValue;
+        private readonly TError? _errorValue;
         private readonly bool _success;
 
-        private Either(TResult result, TError error, bool success)
+        private Either(TResult? result, TError? error, bool success)
         {
             _success = success;
 
@@ -60,7 +60,7 @@ namespace Functional.Either
                 throw new ArgumentNullException(nameof(errorFunc));
             }
 
-            return _success ? resultFunc(_resultValue) : errorFunc(_errorValue);
+            return _success ? resultFunc(_resultValue!) : errorFunc(_errorValue!);
         }
 
         /// <summary>
@@ -98,11 +98,11 @@ namespace Functional.Either
 
             if (_success)
             {
-                resultAction(_resultValue);
+                resultAction(_resultValue!);
             }
             else
             {
-                errorAction(_errorValue);
+                errorAction(_errorValue!);
             }
         }
 
@@ -131,8 +131,8 @@ namespace Functional.Either
             }
         }
 
-        public TResult ResultOrDefault() => Match(res => res, err => default);
-        public TError ErrorOrDefault() => Match(res => default, err => err);
+        public TResult? ResultOrDefault() => Match<TResult?>(res => res, err => default);
+        public TError? ErrorOrDefault() => Match<TError?>(res => default, err => err);
         public TResult ResultOrDefault(TResult defaultValue) => Match(res => res, err => defaultValue);
         public TError ErrorOrDefault(TError defaultValue) => Match(res => defaultValue, err => err);
 

--- a/Functional.Maybe/Functional.Maybe.csproj
+++ b/Functional.Maybe/Functional.Maybe.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard1.0</TargetFramework>
-    <LangVersion>7.2</LangVersion>
+    <LangVersion>9.0</LangVersion>
     <Version>2.0.0</Version>
     <Authors>Andrey Tsvetkov; William Cassarin</Authors>
     <PackageId>Functional.Maybe</PackageId>
@@ -29,6 +29,15 @@
     <PackageReleaseNotes>Migrated to Net Standart 1.0</PackageReleaseNotes>
     <Product>Option types for C# with LINQ support and rich fluent syntax for many popular uses</Product>
     <RepositoryUrl>https://github.com/AndreyTsvetkov/Functional.Maybe</RepositoryUrl>
+    <Nullable>enable</Nullable>
+    <WarningsAsErrors>nullable</WarningsAsErrors>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Nullable" Version="1.3.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 
 </Project>

--- a/Functional.Maybe/Maybe.cs
+++ b/Functional.Maybe/Maybe.cs
@@ -24,7 +24,7 @@ namespace Functional.Maybe
 	/// var result = (from a in list.FirstMaybe() from b in list.LastMaybe() select a + b).OrElse(-5);
 	/// </example>
 	/// <typeparam name="T"></typeparam>
-	public readonly struct Maybe<T> : IEquatable<Maybe<T>>
+	public readonly struct Maybe<T> : IEquatable<Maybe<T>> where T : notnull
 	{
 		/// <summary>
 		/// Nothing value.
@@ -40,7 +40,7 @@ namespace Functional.Maybe
 			get
 			{
 				if (!HasValue) throw new InvalidOperationException("value is not present");
-				return _value;
+				return _value!;
 			}
 		}
 		/// <summary>
@@ -66,7 +66,7 @@ namespace Functional.Maybe
 		}
 
 		public bool Equals(Maybe<T> other) => 
-			EqualityComparer<T>.Default.Equals(_value, other._value) && HasValue.Equals(other.HasValue);
+			EqualityComparer<T?>.Default.Equals(_value, other._value) && HasValue.Equals(other.HasValue);
 
 		public override bool Equals(object obj)
 		{
@@ -78,7 +78,7 @@ namespace Functional.Maybe
 		{
 			unchecked
 			{
-				return (EqualityComparer<T>.Default.GetHashCode(_value)*397) ^ HasValue.GetHashCode();
+				return (EqualityComparer<T?>.Default.GetHashCode(_value)*397) ^ HasValue.GetHashCode();
 			}
 		}
 
@@ -88,6 +88,6 @@ namespace Functional.Maybe
 		public static bool operator !=(Maybe<T> left, Maybe<T> right) =>
 			!left.Equals(right);
 
-		private readonly T _value;
+		private readonly T? _value;
 	}
 }

--- a/Functional.Maybe/MaybeAsync.cs
+++ b/Functional.Maybe/MaybeAsync.cs
@@ -13,20 +13,23 @@ namespace Functional.Maybe
 		/// <param name="this">maybe to map</param>
 		/// <param name="res">async mapper</param>
 		/// <returns>Task of Maybe of TR</returns>
-		public static async Task<Maybe<TR>> SelectAsync<T, TR>(this Maybe<T> @this, Func<T, Task<TR>> res) => @this.HasValue
-			? (await res(@this.Value)).ToMaybe()
-			: (default);
-		public static async Task<T> OrElseAsync<T>(this Task<Maybe<T>> @this, Func<Task<T>> orElse)
+		public static async Task<Maybe<TR>> SelectAsync<T, TR>(this Maybe<T> @this, Func<T, Task<TR?>> res)
+			where T : notnull where TR : notnull =>
+			@this.HasValue
+				? (await res(@this.Value)).ToMaybe()
+				: (default);
+
+		public static async Task<T> OrElseAsync<T>(this Task<Maybe<T>> @this, Func<Task<T>> orElse) where T : notnull
 		{
 			var res = await @this;
 			return res.HasValue ? res.Value : await orElse();
 		}
-		public static async Task<T> OrElse<T>(this Task<Maybe<T>> @this, T orElse)
+		public static async Task<T> OrElse<T>(this Task<Maybe<T>> @this, T orElse) where T : notnull
 		{
 			var res = await @this;
 			return res.HasValue ? res.Value : orElse;
 		}
-		public static async Task<T> OrElse<T>(this Task<Maybe<T>> @this, Func<T> orElse)
+		public static async Task<T> OrElse<T>(this Task<Maybe<T>> @this, Func<T> orElse) where T : notnull
 		{
 			var res = await @this;
 			return res.HasValue ? res.Value : orElse();
@@ -34,12 +37,12 @@ namespace Functional.Maybe
 
 		public static async Task<TR> MatchAsync<T, TR>(this Maybe<T> @this,
 			Func<T, Task<TR>> res,
-			Func<Task<TR>> orElse) => @this.HasValue
+			Func<Task<TR>> orElse)  where T : notnull => @this.HasValue
 			? await res(@this.Value)
 			: await orElse();
 
 		public static async Task DoAsync<T>(this Maybe<T> @this,
-			Func<T, Task> res)
+			Func<T, Task> res) where T : notnull
 		{
 			if (@this.HasValue)
 			{

--- a/Functional.Maybe/MaybeBoolean.cs
+++ b/Functional.Maybe/MaybeBoolean.cs
@@ -14,7 +14,7 @@ namespace Functional.Maybe
 		/// <param name="condition"></param>
 		/// <param name="f"></param>
 		/// <returns></returns>
-		public static Maybe<T> Then<T>(this bool condition, Func<T> f) =>
+		public static Maybe<T> Then<T>(this bool condition, Func<T> f) where T : notnull =>
 			condition ? f().ToMaybe() : default;
 
 		/// <summary>
@@ -24,7 +24,7 @@ namespace Functional.Maybe
 		/// <param name="condition"></param>
 		/// <param name="t"></param>
 		/// <returns></returns>
-		public static Maybe<T> Then<T>(this bool condition, T t) =>
+		public static Maybe<T> Then<T>(this bool condition, T t) where T : notnull =>
 			condition ? t.ToMaybe() : default;
 
 		/// <summary>

--- a/Functional.Maybe/MaybeCompositions.cs
+++ b/Functional.Maybe/MaybeCompositions.cs
@@ -16,7 +16,7 @@ namespace Functional.Maybe
 		/// <param name="a"></param>
 		/// <param name="b"></param>
 		/// <returns></returns>
-		public static Maybe<T> Or<T>(this Maybe<T> a, T b) =>
+		public static Maybe<T> Or<T>(this Maybe<T> a, T b) where T : notnull =>
 			a.IsSomething() ? a : b.ToMaybe();
 
 		/// <summary>
@@ -26,7 +26,7 @@ namespace Functional.Maybe
 		/// <param name="a"></param>
 		/// <param name="b"></param>
 		/// <returns></returns>
-		public static Maybe<T> Or<T>(this Maybe<T> a, Func<Maybe<T>> b) =>
+		public static Maybe<T> Or<T>(this Maybe<T> a, Func<Maybe<T>> b) where T : notnull =>
 			a.IsSomething() ? a : b();
 
 		/// <summary>
@@ -36,7 +36,7 @@ namespace Functional.Maybe
 		/// <param name="a"></param>
 		/// <param name="b"></param>
 		/// <returns></returns>
-		public static Maybe<T> Or<T>(this Maybe<T> a, Maybe<T> b) => a.IsSomething() ? a : b;
+		public static Maybe<T> Or<T>(this Maybe<T> a, Maybe<T> b) where T : notnull => a.IsSomething() ? a : b;
 
 		/// <summary>
 		/// Returns <paramref name="b"/> if <paramref name="a"/> has value, otherwise <see cref="Maybe&lt;T&gt;.Nothing"/>
@@ -46,7 +46,8 @@ namespace Functional.Maybe
 		/// <param name="a"></param>
 		/// <param name="b"></param>
 		/// <returns></returns>
-		public static Maybe<T2> Compose<T, T2>(this Maybe<T> a, Maybe<T2> b) =>
+		public static Maybe<T2> Compose<T, T2>(this Maybe<T> a, Maybe<T2> b) 
+      where T : notnull where T2 : notnull=>
 			a.IsNothing() ? Maybe<T2>.Nothing : b;
 
 		/// <summary>
@@ -55,7 +56,7 @@ namespace Functional.Maybe
 		/// <typeparam name="T"></typeparam>
 		/// <param name="t"></param>
 		/// <returns></returns>
-		public static Maybe<T> Collapse<T>(this Maybe<Maybe<T>> t) => t; // using implicit cast
+		public static Maybe<T> Collapse<T>(this Maybe<Maybe<T>> t) where T : notnull => t; // using implicit cast
 
 		/// <summary>
 		/// Flattens a recursive Maybe structure into IEnumerable
@@ -73,13 +74,13 @@ namespace Functional.Maybe
 		///	]
 		/// </example>
 		/// <returns></returns>
-		public static IEnumerable<T> Flatten<T>(this Maybe<T> maybe, Func<T, Maybe<T>> parentSelector) =>
+		public static IEnumerable<T> Flatten<T>(this Maybe<T> maybe, Func<T, Maybe<T>> parentSelector) where T : notnull =>
 			maybe.FlattenSelect(parentSelector, x => x);
 
-		private static IEnumerable<TFlatten> FlattenSelect<TMaybe, TFlatten>(this Maybe<TMaybe> maybe, Func<TMaybe, Maybe<TMaybe>> parentSelector, Func<TMaybe, TFlatten> flattenSelector) =>
+		private static IEnumerable<TFlatten> FlattenSelect<TMaybe, TFlatten>(this Maybe<TMaybe> maybe, Func<TMaybe, Maybe<TMaybe>> parentSelector, Func<TMaybe, TFlatten> flattenSelector) where TMaybe : notnull =>
 			maybe.Flatten(parentSelector, new List<TFlatten>(), flattenSelector);
 
-		private static IEnumerable<TFlatten> Flatten<TMaybe, TFlatten>(this Maybe<TMaybe> maybe, Func<TMaybe, Maybe<TMaybe>> parentSelector, List<TFlatten> acc, Func<TMaybe, TFlatten> flattenSelector)
+		private static IEnumerable<TFlatten> Flatten<TMaybe, TFlatten>(this Maybe<TMaybe> maybe, Func<TMaybe, Maybe<TMaybe>> parentSelector, List<TFlatten> acc, Func<TMaybe, TFlatten> flattenSelector) where TMaybe : notnull
 		{
 			while (true)
 			{

--- a/Functional.Maybe/MaybeConvertions.cs
+++ b/Functional.Maybe/MaybeConvertions.cs
@@ -15,7 +15,7 @@ namespace Functional.Maybe
 		/// <typeparam name="TB"></typeparam>
 		/// <param name="a"></param>
 		/// <returns></returns>
-		public static Maybe<TB> Cast<TA, TB>(this Maybe<TA> a) where TB : class =>
+		public static Maybe<TB> Cast<TA, TB>(this Maybe<TA> a) where TB : class where TA : notnull =>
 			from m in a
 			let t = m as TB
 			where t != null
@@ -28,7 +28,7 @@ namespace Functional.Maybe
 		/// <typeparam name="TR"></typeparam>
 		/// <param name="a"></param>
 		/// <returns></returns>
-		public static Maybe<TR> MaybeCast<T, TR>(this T a) where TR : T =>
+		public static Maybe<TR> MaybeCast<T, TR>(this T a) where TR : T where T : notnull =>
 			MaybeFunctionalWrappers.Catcher<T, TR, InvalidCastException>(o => (TR)o)(a);
 
 		/// <summary>
@@ -37,7 +37,7 @@ namespace Functional.Maybe
 		/// <typeparam name="T"></typeparam>
 		/// <param name="a"></param>
 		/// <returns></returns>
-		public static IEnumerable<T> ToEnumerable<T>(this Maybe<T> a)
+		public static IEnumerable<T> ToEnumerable<T>(this Maybe<T> a) where T : notnull
 		{
 			if (a.IsSomething())
 				yield return a.Value;
@@ -67,7 +67,7 @@ namespace Functional.Maybe
 		/// <typeparam name="T"></typeparam>
 		/// <param name="a"></param>
 		/// <returns></returns>
-		public static Maybe<T> ToMaybe<T>(this T a) =>
+		public static Maybe<T> ToMaybe<T>(this T? a) where T : notnull =>
 			a == null ? default : new Maybe<T>(a);
 	}
 }

--- a/Functional.Maybe/MaybeDictionary.cs
+++ b/Functional.Maybe/MaybeDictionary.cs
@@ -12,7 +12,7 @@ namespace Functional.Maybe
 		/// <param name="dictionary"></param>
 		/// <param name="key"></param>
 		/// <returns></returns>
-		public static Maybe<T> Lookup<TK, T>(this IDictionary<TK, T> dictionary, TK key)
+		public static Maybe<T> Lookup<TK, T>(this IDictionary<TK, T> dictionary, TK key) where T : notnull
 		{
 			var getter = MaybeFunctionalWrappers.Wrap<TK, T>(dictionary.TryGetValue);
 			return getter(key);

--- a/Functional.Maybe/MaybeEnumerable.cs
+++ b/Functional.Maybe/MaybeEnumerable.cs
@@ -15,35 +15,36 @@ namespace Functional.Maybe
 		/// <typeparam name="T"></typeparam>
 		/// <param name="items"></param>
 		/// <returns></returns>
-		public static Maybe<T> FirstMaybe<T>(this IEnumerable<T> items) => 
+		public static Maybe<T> FirstMaybe<T>(this IEnumerable<T> items) where T : notnull => 
 			FirstMaybe(items, arg => true);
 
-		/// <summary>
-		/// First item matching <paramref name="predicate"/> or Nothing
-		/// </summary>
-		/// <typeparam name="T"></typeparam>
-		/// <param name="items"></param>
-		/// <param name="predicate"></param>
-		/// <returns></returns>
-		public static Maybe<T> FirstMaybe<T>(this IEnumerable<T> items, Func<T, bool> predicate)
-	    {
-	        foreach(var item in items)
-			{
-	            if (predicate(item))
-				{
-	                return item.ToMaybe();
-	            }
-	        }
-	        return Maybe<T>.Nothing;
-	    }
+    /// <summary>
+    /// First item matching <paramref name="predicate"/> or Nothing
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="items"></param>
+    /// <param name="predicate"></param>
+    /// <returns></returns>
+    public static Maybe<T> FirstMaybe<T>(this IEnumerable<T> items, Func<T, bool> predicate) where T : notnull
+    {
+      foreach (var item in items)
+      {
+        if (predicate(item))
+        {
+          return item.ToMaybe();
+        }
+      }
 
-		/// <summary>
+      return Maybe<T>.Nothing;
+    }
+
+    /// <summary>
 		/// Single item or Nothing
 		/// </summary>
 		/// <typeparam name="T"></typeparam>
 		/// <param name="items"></param>
 		/// <returns></returns>
-		public static Maybe<T> SingleMaybe<T>(this IEnumerable<T> items) => 
+		public static Maybe<T> SingleMaybe<T>(this IEnumerable<T> items) where T : notnull => 
 			SingleMaybe(items, arg => true);
 
 		/// <summary>
@@ -53,62 +54,67 @@ namespace Functional.Maybe
 		/// <param name="items"></param>
 		/// <param name="predicate"></param>
 		/// <returns></returns>
-		public static Maybe<T> SingleMaybe<T>(this IEnumerable<T> items, Func<T, bool> predicate)
+		public static Maybe<T> SingleMaybe<T>(this IEnumerable<T> items, Func<T, bool> predicate) where T : notnull
 		{
-            var result = default(T);
-            var count = 0;
-            foreach(var element in items)
+			var result = default(T);
+			var count = 0;
+			foreach (var element in items)
 			{
-                if (predicate(element))
+				if (predicate(element))
 				{
-                    result = element;
-                    count++;
+					result = element;
+					count++;
 					if (count > 1)
 					{
 						return default;
 					}
-                }
-            }
-            switch(count)
-			{
-                case 0: return default;
-                case 1: return result.ToMaybe();
-            }
-            return default;
-        }
+				}
+			}
 
-		/// <summary>
+			switch (count)
+			{
+				case 0:
+					return default;
+				case 1:
+					return result.ToMaybe();
+			}
+
+			return default;
+		}
+
+    /// <summary>
 		/// Last item or Nothing
 		/// </summary>
 		/// <typeparam name="T"></typeparam>
 		/// <param name="items"></param>
 		/// <returns></returns>
-		public static Maybe<T> LastMaybe<T>(this IEnumerable<T> items) => 
+		public static Maybe<T> LastMaybe<T>(this IEnumerable<T> items) where T : notnull => 
 			LastMaybe(items, arg => true);
 
-		/// <summary>
-		/// Last item matching <paramref name="predicate"/> or Nothing
-		/// </summary>
-		/// <typeparam name="T"></typeparam>
-		/// <param name="items"></param>
-		/// <param name="predicate"></param>
-		/// <returns></returns>
-		public static Maybe<T> LastMaybe<T>(this IEnumerable<T> items, Func<T, bool> predicate)
+    /// <summary>
+    /// Last item matching <paramref name="predicate"/> or Nothing
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="items"></param>
+    /// <param name="predicate"></param>
+    /// <returns></returns>
+    public static Maybe<T> LastMaybe<T>(this IEnumerable<T> items, Func<T, bool> predicate) where T : notnull
+    {
+	    var result = default(T);
+	    var found = false;
+	    foreach (var element in items)
 	    {
-	        var result = default(T);
-	        var found = false;
-	        foreach (var element in items)
-			{
-	            if (predicate(element))
-				{
-	                result = element;
-	                found = true;
-	            }
-	        }
-			return found ? result.ToMaybe() : default;
-		}
+		    if (predicate(element))
+		    {
+			    result = element;
+			    found = true;
+		    }
+	    }
 
-		/// <summary>
+	    return found ? result.ToMaybe() : default;
+    }
+
+    /// <summary>
 		/// Returns the value of <paramref name="maybeCollection"/> if exists orlse an empty collection
 		/// </summary>
 		/// <typeparam name="T"></typeparam>
@@ -125,7 +131,8 @@ namespace Functional.Maybe
 		/// <param name="maybes"></param>
 		/// <param name="selector"></param>
 		/// <returns></returns>
-		public static IEnumerable<Maybe<TResult>> Select<T, TResult>(this IEnumerable<Maybe<T>> maybes, Func<T, TResult> selector) =>
+		public static IEnumerable<Maybe<TResult>> Select<T, TResult>(this IEnumerable<Maybe<T>> maybes, Func<T, TResult?> selector) 
+      where T : notnull where TResult : notnull =>
 			maybes.Select(maybe => maybe.Select(selector));
 
 		/// <summary>
@@ -134,7 +141,7 @@ namespace Functional.Maybe
 		/// <typeparam name="T"></typeparam>
 		/// <param name="maybes"></param>
 		/// <returns></returns>
-		public static Maybe<IEnumerable<T>> WholeSequenceOfValues<T>(this IEnumerable<Maybe<T>> maybes)
+		public static Maybe<IEnumerable<T>> WholeSequenceOfValues<T>(this IEnumerable<Maybe<T>> maybes) where T : notnull
 		{
 			var forced = maybes.ToArray();
 			// there has got to be a better way to do this
@@ -150,7 +157,7 @@ namespace Functional.Maybe
 		/// <typeparam name="T"></typeparam>
 		/// <param name="maybes"></param>
 		/// <returns></returns>
-		public static IEnumerable<T> WhereValueExist<T>(this IEnumerable<Maybe<T>> maybes) => 
+		public static IEnumerable<T> WhereValueExist<T>(this IEnumerable<Maybe<T>> maybes) where T : notnull => 
 			SelectWhereValueExist(maybes, m => m);
 
 		/// <summary>
@@ -161,7 +168,7 @@ namespace Functional.Maybe
 		/// <param name="maybes"></param>
 		/// <param name="fn"></param>
 		/// <returns></returns>
-		public static IEnumerable<TResult> SelectWhereValueExist<T, TResult>(this IEnumerable<Maybe<T>> maybes, Func<T, TResult> fn) =>
+		public static IEnumerable<TResult> SelectWhereValueExist<T, TResult>(this IEnumerable<Maybe<T>> maybes, Func<T, TResult> fn) where T : notnull =>
 			from maybe in maybes
 			where maybe.HasValue
 			select fn(maybe.Value);
@@ -172,7 +179,7 @@ namespace Functional.Maybe
 		/// <typeparam name="T"></typeparam>
 		/// <param name="maybes"></param>
 		/// <returns></returns>
-		public static bool AnyNothing<T>(this IEnumerable<Maybe<T>> maybes) =>
+		public static bool AnyNothing<T>(this IEnumerable<Maybe<T>> maybes) where T : notnull =>
 			maybes.Any(m => !m.HasValue);
 
 		/// <summary>
@@ -216,7 +223,7 @@ namespace Functional.Maybe
 		/// <param name="this"></param>
 		/// <param name="others"></param>
 		/// <returns></returns>
-		public static IEnumerable<T> Union<T>(this Maybe<T> @this, params Maybe<T>[] others) =>
+		public static IEnumerable<T> Union<T>(this Maybe<T> @this, params Maybe<T>[] others) where T : notnull =>
 			@this.Union(others.WhereValueExist());
 
 		/// <summary>
@@ -226,7 +233,7 @@ namespace Functional.Maybe
 		/// <param name="this"></param>
 		/// <param name="others"></param>
 		/// <returns></returns>
-		public static IEnumerable<T> Union<T>(this Maybe<T> @this, IEnumerable<T> others) =>
+		public static IEnumerable<T> Union<T>(this Maybe<T> @this, IEnumerable<T> others) where T : notnull =>
 			@this.ToEnumerable().Union(others);
 
 		/// <summary>
@@ -236,7 +243,7 @@ namespace Functional.Maybe
 		/// <param name="this"></param>
 		/// <param name="others"></param>
 		/// <returns></returns>
-		public static IEnumerable<T> Union<T>(this IEnumerable<T> @these, Maybe<T> other) =>
+		public static IEnumerable<T> Union<T>(this IEnumerable<T> @these, Maybe<T> other) where T : notnull =>
 			@these.Union(other.ToEnumerable());
 	}
 }

--- a/Functional.Maybe/MaybeFunctionalWrappers.cs
+++ b/Functional.Maybe/MaybeFunctionalWrappers.cs
@@ -24,7 +24,7 @@ namespace Functional.Maybe
 		/// <typeparam name="T"></typeparam>
 		/// <param name="tryer"></param>
 		/// <returns></returns>
-		public static Func<T, Maybe<TR>> Wrap<T, TR>(TryGet<T, TR> tryer) => (T arg) =>
+		public static Func<T, Maybe<TR>> Wrap<T, TR>(TryGet<T, TR> tryer)  where TR : notnull => (T arg) =>
 		{
 			TR result;
 			return tryer(arg, out result)
@@ -41,7 +41,7 @@ namespace Functional.Maybe
 		/// <typeparam name="TEx"></typeparam>
 		/// <param name="f"></param>
 		/// <returns></returns>
-		public static Func<TA, Maybe<TR>> Catcher<TA, TR, TEx>(Func<TA, TR> f) where TEx : Exception => (TA arg) =>
+		public static Func<TA, Maybe<TR>> Catcher<TA, TR, TEx>(Func<TA, TR> f) where TEx : Exception where TR : notnull => (TA arg) =>
 		{
 			try
 			{

--- a/Functional.Maybe/MaybeLinq.cs
+++ b/Functional.Maybe/MaybeLinq.cs
@@ -15,7 +15,8 @@ namespace Functional.Maybe
 		/// <param name="a"></param>
 		/// <param name="fn"></param>
 		/// <returns></returns>
-		public static Maybe<TResult> Select<T, TResult>(this Maybe<T> a, Func<T, TResult> fn)
+		public static Maybe<TResult> Select<T, TResult>(this Maybe<T> a, Func<T, TResult?> fn) 
+      where T : notnull where TResult : notnull
 		{
 			if (a.HasValue)
 			{
@@ -37,7 +38,7 @@ namespace Functional.Maybe
 		/// <param name="fn"></param>
 		/// <param name="else"></param>
 		/// <returns></returns>
-		public static TResult SelectOrElse<T, TResult>(this Maybe<T> a, Func<T, TResult> fn, Func<TResult> @else) => 
+		public static TResult SelectOrElse<T, TResult>(this Maybe<T> a, Func<T, TResult> fn, Func<TResult> @else) where T : notnull => 
 			a.HasValue ? fn(a.Value) : @else();
 		/// <summary>
 		/// If <paramref name="a"/> has value, and it fulfills the <paramref name="predicate"/>, returns <paramref name="a"/>, otherwise returns Nothing
@@ -46,7 +47,7 @@ namespace Functional.Maybe
 		/// <param name="a"></param>
 		/// <param name="predicate"></param>
 		/// <returns></returns>
-		public static Maybe<T> Where<T>(this Maybe<T> a, Func<T, bool> predicate) => 
+		public static Maybe<T> Where<T>(this Maybe<T> a, Func<T, bool> predicate) where T : notnull => 
 			a.HasValue && predicate(a.Value) ? a : default;
 		/// <summary>
 		/// If <paramref name="a"/> has value, applies <paramref name="fn"/> to it and returns, otherwise returns Nothing
@@ -56,7 +57,8 @@ namespace Functional.Maybe
 		/// <param name="a"></param>
 		/// <param name="fn"></param>
 		/// <returns></returns>
-		public static Maybe<TR> SelectMany<T, TR>(this Maybe<T> a, Func<T, Maybe<TR>> fn) => 
+		public static Maybe<TR> SelectMany<T, TR>(this Maybe<T> a, Func<T, Maybe<TR>> fn) 
+      where T : notnull where TR : notnull => 
 			a.HasValue ? fn(a.Value) : default;
 
 		/// <summary>
@@ -70,7 +72,8 @@ namespace Functional.Maybe
 		/// <param name="fn"></param>
 		/// <param name="composer"></param>
 		/// <returns></returns>
-		public static Maybe<TResult> SelectMany<T, TTempResult, TResult>(this Maybe<T> a, Func<T, Maybe<TTempResult>> fn, Func<T, TTempResult, TResult> composer) => 
+		public static Maybe<TResult> SelectMany<T, TTempResult, TResult>(this Maybe<T> a, Func<T, Maybe<TTempResult>> fn, Func<T, TTempResult, TResult?> composer) 
+			where T : notnull where TResult : notnull where TTempResult : notnull => 
 			a.SelectMany(x => fn(x).SelectMany(y => composer(x, y).ToMaybe()));
 
 		/// <summary>
@@ -81,7 +84,8 @@ namespace Functional.Maybe
 		/// <param name="a"></param>
 		/// <param name="fn"></param>
 		/// <returns></returns>
-		public static Maybe<TR> SelectMaybe<T, TR>(this Maybe<T> a, Func<T, Maybe<TR>> fn) =>
+		public static Maybe<TR> SelectMaybe<T, TR>(this Maybe<T> a, Func<T, Maybe<TR>> fn) 
+			where T : notnull where TR : notnull =>
 			a.SelectMany(fn);
 
 		/// <summary>
@@ -95,7 +99,8 @@ namespace Functional.Maybe
 		/// <param name="fn"></param>
 		/// <param name="composer"></param>
 		/// <returns></returns>
-		public static Maybe<TResult> SelectMaybe<T, TTempResult, TResult>(this Maybe<T> a, Func<T, Maybe<TTempResult>> fn, Func<T, TTempResult, TResult> composer) =>
+		public static Maybe<TResult> SelectMaybe<T, TTempResult, TResult>(this Maybe<T> a, Func<T, Maybe<TTempResult>> fn, Func<T, TTempResult, TResult?> composer) 
+      where T : notnull where TResult : notnull where TTempResult : notnull =>
 			a.SelectMany(fn, composer);
 	}
 }

--- a/Functional.Maybe/MaybeReturns.cs
+++ b/Functional.Maybe/MaybeReturns.cs
@@ -14,7 +14,7 @@ namespace Functional.Maybe
 		/// <param name="a"></param>
 		/// <param name="default"></param>
 		/// <returns></returns>
-		public static string ReturnToString<T>(this Maybe<T> a, string @default)
+		public static string ReturnToString<T>(this Maybe<T> a, string @default) where T : notnull
 		{
 			return a.HasValue ? a.Value.ToString() : @default;
 		}
@@ -26,7 +26,7 @@ namespace Functional.Maybe
 		/// <param name="a"></param>
 		/// <param name="e"></param>
 		/// <returns></returns>
-		public static T OrElse<T>(this Maybe<T> a, Func<Exception> e)
+		public static T OrElse<T>(this Maybe<T> a, Func<Exception> e)  where T : notnull
 		{
 			if (a.IsNothing())
 			{
@@ -42,7 +42,7 @@ namespace Functional.Maybe
 		/// <param name="a"></param>
 		/// <param name="default"></param>
 		/// <returns></returns>
-		public static T OrElse<T>(this Maybe<T> a, Func<T> @default) =>
+		public static T OrElse<T>(this Maybe<T> a, Func<T> @default)  where T : notnull =>
 			a.HasValue ? a.Value : @default();
 
 		/// <summary>
@@ -51,7 +51,7 @@ namespace Functional.Maybe
 		/// <typeparam name="T"></typeparam>
 		/// <param name="a"></param>
 		/// <returns></returns>
-		public static T OrElseDefault<T>(this Maybe<T> a) =>
+		public static T? OrElseDefault<T>(this Maybe<T> a) where T : notnull =>
 			a.HasValue ? a.Value : default;
 
 		/// <summary>
@@ -61,7 +61,7 @@ namespace Functional.Maybe
 		/// <param name="a"></param>
 		/// <param name="default"></param>
 		/// <returns></returns>
-		public static T OrElse<T>(this Maybe<T> a, T @default) =>
+		public static T OrElse<T>(this Maybe<T> a, T @default) where T : notnull =>
 			a.HasValue ? a.Value : @default;
 	}
 }

--- a/Functional.Maybe/MaybeSideEffects.cs
+++ b/Functional.Maybe/MaybeSideEffects.cs
@@ -14,7 +14,7 @@ namespace Functional.Maybe
 		/// <param name="m"></param>
 		/// <param name="fn"></param>
 		/// <returns></returns>
-		public static Maybe<T> Do<T>(this Maybe<T> m, Action<T> fn)
+		public static Maybe<T> Do<T>(this Maybe<T> m, Action<T> fn) where T : notnull
 		{
 			if (m.IsSomething())
 				fn(m.Value);
@@ -29,7 +29,7 @@ namespace Functional.Maybe
 		/// <param name="fn"></param>
 		/// <param name="else"></param>
 		/// <returns></returns>
-		public static Maybe<T> Match<T>(this Maybe<T> m, Action<T> fn, Action @else)
+		public static Maybe<T> Match<T>(this Maybe<T> m, Action<T> fn, Action @else) where T : notnull
 		{
 			if (m.IsSomething())
 				fn(m.Value);

--- a/Functional.Maybe/MaybeSomethingNothingHelpers.cs
+++ b/Functional.Maybe/MaybeSomethingNothingHelpers.cs
@@ -14,7 +14,7 @@ namespace Functional.Maybe
 		/// <param name="a"></param>
 		/// <returns></returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static bool IsSomething<T>(this Maybe<T> a) => a.HasValue;
+		public static bool IsSomething<T>(this Maybe<T> a) where T : notnull => a.HasValue;
 
 		/// <summary>
 		/// Has no value inside
@@ -23,7 +23,7 @@ namespace Functional.Maybe
 		/// <param name="a"></param>
 		/// <returns></returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static bool IsNothing<T>(this Maybe<T> a) => !a.IsSomething();
+		public static bool IsNothing<T>(this Maybe<T> a) where T : notnull => !a.IsSomething();
 
 		/// <summary>
 		/// Создает "ничто" такого же типа, как исходный объект
@@ -32,7 +32,7 @@ namespace Functional.Maybe
 		/// <param name="_"></param>
 		/// <returns></returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Maybe<T> NothingOf<T>(this Maybe<T> _) => default;
+		public static Maybe<T> NothingOf<T>(this Maybe<T> _) where T : notnull => default;
 
 		/// <summary>
 		/// Создает "ничто" такого же типа, как исходный объект
@@ -41,6 +41,6 @@ namespace Functional.Maybe
 		/// <param name="_"></param>
 		/// <returns></returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Maybe<T> NothingOf<T>(this T _) => default;
+		public static Maybe<T> NothingOf<T>(this T _) where T : notnull => default;
 	}
 }


### PR DESCRIPTION
Hi, this PR adds preliminary support for nullable reference types. I am missing them when working with Maybe<>, because, for instance, when converting an NRT to maybe, I have to write `nullableRef!.ToMaybe()` (otherwise I get a `Maybe<T?>`) and also the `OrElseDefault()` is not marked as possibly returning a null, which confuses the NRT analysis.

As mentioned, this PR is preliminary, because I don't know if you are interested at all in supporting NRTs. If so, I am willing to work more on this PR, since there are some open topics for discussion (one that comes into my mind: should Maybe allow nulls in code such as `maybe.OrElse(null)`).

If you are not interested, please reject.