### PR TITLE
Complete implementation of NRT compatibility

### DIFF
--- a/Functional.Maybe.NTests/EitherTests.cs
+++ b/Functional.Maybe.NTests/EitherTests.cs
@@ -23,21 +23,21 @@ namespace Functional.Maybe.Tests
        [Test]
         public void NullCheckingTests()
         {
-            Action<int> nullActionInt = null;
+            Action<int>? nullActionInt = null;
 
             void MockActionInt(int x)
             {
                 var y = 5;
             }
 
-            Action<string> nullActionString = null;
+            Action<string>? nullActionString = null;
 
             void MockActionString(string x)
             {
                 var y = 5;
             }
 
-            Action nullAction = null;
+            Action? nullAction = null;
 
             void MockAction()
             {
@@ -45,16 +45,16 @@ namespace Functional.Maybe.Tests
             }
 
             // ReSharper disable ExpressionIsAlwaysNull
-            AssertExtension.Throws<ArgumentNullException>(() => _eitherResult.Match(nullAction, MockAction));
-            AssertExtension.Throws<ArgumentNullException>(() => _eitherResult.Match(MockAction, nullAction));
+            AssertExtension.Throws<ArgumentNullException>(() => _eitherResult.Match(nullAction!, MockAction));
+            AssertExtension.Throws<ArgumentNullException>(() => _eitherResult.Match(MockAction, nullAction!));
             _eitherResult.Match(MockAction, MockAction);
 
-            AssertExtension.Throws<ArgumentNullException>(() => _eitherError.Match(nullAction, MockAction));
-            AssertExtension.Throws<ArgumentNullException>(() => _eitherError.Match(MockAction, nullAction));
+            AssertExtension.Throws<ArgumentNullException>(() => _eitherError.Match(nullAction!, MockAction));
+            AssertExtension.Throws<ArgumentNullException>(() => _eitherError.Match(MockAction, nullAction!));
             _eitherError.Match(MockAction, MockAction);
 
-            AssertExtension.Throws<ArgumentNullException>(() => _eitherError.Match(nullActionInt, MockActionString));
-            AssertExtension.Throws<ArgumentNullException>(() => _eitherError.Match(MockActionInt, nullActionString));
+            AssertExtension.Throws<ArgumentNullException>(() => _eitherError.Match(nullActionInt!, MockActionString));
+            AssertExtension.Throws<ArgumentNullException>(() => _eitherError.Match(MockActionInt, nullActionString!));
             _eitherResult.Match(MockActionInt, MockActionString);
         }
 

--- a/Functional.Maybe.NTests/Functional.Maybe.NTests.csproj
+++ b/Functional.Maybe.NTests/Functional.Maybe.NTests.csproj
@@ -8,6 +8,7 @@
 		<LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <WarningsAsErrors>nullable</WarningsAsErrors>
+    <RootNamespace>Functional.Maybe.Tests</RootNamespace>
   </PropertyGroup>
 
 	<ItemGroup>

--- a/Functional.Maybe.NTests/Functional.Maybe.NTests.csproj
+++ b/Functional.Maybe.NTests/Functional.Maybe.NTests.csproj
@@ -1,12 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netcoreapp2.2</TargetFramework>
+		<TargetFramework>net5.0</TargetFramework>
 
 		<IsPackable>false</IsPackable>
 
 		<LangVersion>latest</LangVersion>
-	</PropertyGroup>
+    <Nullable>enable</Nullable>
+    <WarningsAsErrors>nullable</WarningsAsErrors>
+  </PropertyGroup>
 
 	<ItemGroup>
 		<PackageReference Include="nunit" Version="3.11.0" />

--- a/Functional.Maybe.NTests/MaybeAsyncTests.cs
+++ b/Functional.Maybe.NTests/MaybeAsyncTests.cs
@@ -60,7 +60,16 @@ namespace Functional.Maybe.Tests
 			Assert.IsNull(result);
 		}
 
-		//bug also OrElseAsync
+		[Test]
+		public async Task OrElseAsyncWithNullAlternativeValueTest()
+    {
+			var taskOfMaybe = Task.FromResult(Maybe<string>.Nothing);
+		
+			var result = await taskOfMaybe.OrElseAsync(
+        () => Task.FromResult(null as string));
+		
+			Assert.IsNull(result);
+		}
 
 		[Test]
 		public async Task OrElseWithNullAlternativeFuncResultTest()

--- a/Functional.Maybe.NTests/MaybeAsyncTests.cs
+++ b/Functional.Maybe.NTests/MaybeAsyncTests.cs
@@ -61,12 +61,12 @@ namespace Functional.Maybe.Tests
 		}
 
 		[Test]
-		public async Task OrElseAsyncWithNullAlternativeValueTest()
-    {
+		public async Task OrElseAsyncWithNullAlternativeValueTest() 
+		{
 			var taskOfMaybe = Task.FromResult(Maybe<string>.Nothing);
 		
 			var result = await taskOfMaybe.OrElseAsync(
-        () => Task.FromResult(null as string));
+				() => Task.FromResult(null as string));
 		
 			Assert.IsNull(result);
 		}

--- a/Functional.Maybe.NTests/MaybeAsyncTests.cs
+++ b/Functional.Maybe.NTests/MaybeAsyncTests.cs
@@ -15,5 +15,61 @@ namespace Functional.Maybe.Tests
 
 			Assert.AreEqual(3, onePlusTwo.Value);
 		}
+
+		[Test]
+		public async Task SelectAsyncWithTransformationReturningNullTest()
+		{
+			Task<string?> GetNull() => Task.FromResult<string?>(null);
+
+			var result = await "a".ToMaybe().SelectAsync(async _ => await GetNull());
+
+			Assert.AreEqual(Maybe<string>.Nothing, result);
+		}
+
+		[Test]
+		public async Task MatchAsyncWithValueTransformationReturningNullTest()
+		{
+			Task<string?> GetNull() => Task.FromResult<string?>(null);
+
+			var result = await "a".ToMaybe().MatchAsync(
+				async _ => await GetNull(),
+				() => Task.FromResult<string?>("a"));
+
+			Assert.IsNull(result);
+		}
+
+		[Test]
+		public async Task MatchAsyncWithAlternativeFunctionReturningNullTest()
+		{
+			Task<string?> GetNull() => Task.FromResult<string?>(null);
+
+			var result = await Maybe<string>.Nothing.MatchAsync(
+				_ => Task.FromResult<string?>("a"),
+				async () => await GetNull());
+
+			Assert.IsNull(result);
+		}
+
+		[Test]
+		public async Task OrElseWithNullAlternativeValueTest()
+		{
+			var taskOfMaybe = Task.FromResult(Maybe<string>.Nothing);
+
+			var result = await taskOfMaybe.OrElse(null as string);
+
+			Assert.IsNull(result);
+		}
+
+		//bug also OrElseAsync
+
+		[Test]
+		public async Task OrElseWithNullAlternativeFuncResultTest()
+		{
+			var taskOfMaybe = Task.FromResult(Maybe<string>.Nothing);
+
+			var result = await taskOfMaybe.OrElse(() => null as string);
+
+			Assert.IsNull(result);
+		}
 	}
 }

--- a/Functional.Maybe.NTests/MaybeCannotContainNull.cs
+++ b/Functional.Maybe.NTests/MaybeCannotContainNull.cs
@@ -8,7 +8,7 @@ namespace Functional.Maybe.Tests
 	{
 		private class User
 		{
-			public string Name { get; set; }
+			public string? Name { get; set; }
 		}
 
 		[Test]

--- a/Functional.Maybe.NTests/MaybeCannotContainNull.cs
+++ b/Functional.Maybe.NTests/MaybeCannotContainNull.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 
 namespace Functional.Maybe.Tests
 {

--- a/Functional.Maybe.NTests/MaybeConvertionsTests.cs
+++ b/Functional.Maybe.NTests/MaybeConvertionsTests.cs
@@ -2,35 +2,35 @@
 
 namespace Functional.Maybe.Tests
 {
-  class MaybeConvertionsTests
-  {
-    [Test]
-    public void MaybeCastConvertsValueToItsMaybe()
-    {
-      var result = "a".MaybeCast<string, string>();
-      Assert.AreEqual("a".ToMaybe(), result);
-    }
+	class MaybeConvertionsTests
+	{
+		[Test]
+		public void MaybeCastConvertsValueToItsMaybe()
+		{
+			var result = "a".MaybeCast<string, string>();
+			Assert.AreEqual("a".ToMaybe(), result);
+		}
 
-    [Test]
-    public void MaybeCastConvertsValueOfNrtToItsMaybe()
-    {
-      var result = "a".MaybeCast<string?, string>();
-      Assert.AreEqual("a".ToMaybe(), result);
-    }
+		[Test]
+		public void MaybeCastConvertsValueOfNrtToItsMaybe()
+		{
+			var result = "a".MaybeCast<string?, string>();
+			Assert.AreEqual("a".ToMaybe(), result);
+		}
 
-    [Test]
-    public void MaybeCastConvertsNonCastableValueOfNrtToNothing()
-    {
-      var result = "a".MaybeCast<object?, int>();
-      Assert.AreEqual(Maybe<int>.Nothing, result);
-    }
+		[Test]
+		public void MaybeCastConvertsNonCastableValueOfNrtToNothing()
+		{
+			var result = "a".MaybeCast<object?, int>();
+			Assert.AreEqual(Maybe<int>.Nothing, result);
+		}
 
-    [Test]
-    public void MaybeCastConvertsNullToNothing()
-    {
-      var result = (null as string).MaybeCast<string?, string>();
-      Assert.AreEqual(Maybe<string>.Nothing, result);
-    }
+		[Test]
+		public void MaybeCastConvertsNullToNothing()
+		{
+			var result = (null as string).MaybeCast<string?, string>();
+			Assert.AreEqual(Maybe<string>.Nothing, result);
+		}
 
-  }
+	}
 }

--- a/Functional.Maybe.NTests/MaybeConvertionsTests.cs
+++ b/Functional.Maybe.NTests/MaybeConvertionsTests.cs
@@ -5,24 +5,32 @@ namespace Functional.Maybe.Tests
   class MaybeConvertionsTests
   {
     [Test]
-    public void METHOD1() //bug
+    public void MaybeCastConvertsValueToItsMaybe()
     {
       var result = "a".MaybeCast<string, string>();
       Assert.AreEqual("a".ToMaybe(), result);
     }
 
     [Test]
-    public void METHOD2() //bug
+    public void MaybeCastConvertsValueOfNrtToItsMaybe()
+    {
+      var result = "a".MaybeCast<string?, string>();
+      Assert.AreEqual("a".ToMaybe(), result);
+    }
+
+    [Test]
+    public void MaybeCastConvertsNonCastableValueOfNrtToNothing()
+    {
+      var result = "a".MaybeCast<object?, int>();
+      Assert.AreEqual(Maybe<int>.Nothing, result);
+    }
+
+    [Test]
+    public void MaybeCastConvertsNullToNothing()
     {
       var result = (null as string).MaybeCast<string?, string>();
       Assert.AreEqual(Maybe<string>.Nothing, result);
     }
 
-    [Test]
-    public void METHOD3() //bug
-    {
-      var result = "a".MaybeCast<string?, string>();
-      Assert.AreEqual("a".ToMaybe(), result);
-    }
   }
 }

--- a/Functional.Maybe.NTests/MaybeConvertionsTests.cs
+++ b/Functional.Maybe.NTests/MaybeConvertionsTests.cs
@@ -1,0 +1,28 @@
+﻿using NUnit.Framework;
+
+namespace Functional.Maybe.NTests
+{
+  class MaybeConvertionsTests
+  {
+    [Test]
+    public void METHOD1() //bug
+    {
+      var result = "a".MaybeCast<string, string>();
+      Assert.AreEqual("a".ToMaybe(), result);
+    }
+
+    [Test]
+    public void METHOD2() //bug
+    {
+      var result = (null as string).MaybeCast<string?, string>();
+      Assert.AreEqual(Maybe<string>.Nothing, result);
+    }
+
+    [Test]
+    public void METHOD3() //bug
+    {
+      var result = "a".MaybeCast<string?, string>();
+      Assert.AreEqual("a".ToMaybe(), result);
+    }
+  }
+}

--- a/Functional.Maybe.NTests/MaybeConvertionsTests.cs
+++ b/Functional.Maybe.NTests/MaybeConvertionsTests.cs
@@ -1,6 +1,6 @@
 ﻿using NUnit.Framework;
 
-namespace Functional.Maybe.NTests
+namespace Functional.Maybe.Tests
 {
   class MaybeConvertionsTests
   {

--- a/Functional.Maybe.NTests/MaybeDictionaryNrtTests.cs
+++ b/Functional.Maybe.NTests/MaybeDictionaryNrtTests.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace Functional.Maybe.NTests
+{
+  class MaybeDictionaryNrtTests
+  {
+    [Test]
+    public void METHOD1() //bug
+    {
+      var dictionary = new Dictionary<string, string?>();
+
+      var maybe = dictionary.LookupNrt("a");
+
+      Assert.AreEqual(Maybe<string>.Nothing, maybe);
+    }
+
+    [Test]
+    public void METHOD2() //bug
+    {
+      var dictionary = new Dictionary<string, string?>
+      {
+        ["a"] = null
+      };
+
+      var maybe = dictionary.LookupNrt("a");
+
+      Assert.AreEqual(Maybe<string>.Nothing, maybe);
+    }
+
+    [Test]
+    public void METHOD3() //bug
+    {
+      var dictionary = new Dictionary<string, string?>
+      {
+        ["a"] = "b"
+      };
+
+      var maybe = dictionary.LookupNrt("a");
+
+      Assert.AreEqual("b".ToMaybe(), maybe);
+    }
+  }
+}

--- a/Functional.Maybe.NTests/MaybeDictionaryTests.cs
+++ b/Functional.Maybe.NTests/MaybeDictionaryTests.cs
@@ -6,37 +6,37 @@ namespace Functional.Maybe.Tests
 	class MaybeDictionaryTests
 	{
 		[Test]
-		public void LookupNrtReturnsNothingWhenThereIsNoValueForKey()
+		public void LookupReturnsNothingWhenThereIsNoNrtValueForKey()
 		{
 			var dictionary = new Dictionary<string, string?>();
 
-			var maybe = dictionary.LookupNrt("a");
+			var maybe = dictionary.Lookup<string, string?, string>("a");
 
 			Assert.AreEqual(Maybe<string>.Nothing, maybe);
 		}
 
 		[Test]
-		public void LookupNrtReturnsNothingWhenValueForKeyIsNull()
+		public void LookupReturnsNothingWhenNrtValueForKeyIsNull()
 		{
 			var dictionary = new Dictionary<string, string?>
 			{
 				["a"] = null
 			};
 
-			var maybe = dictionary.LookupNrt("a");
+			var maybe = dictionary.Lookup<string, string?, string>("a");
 
 			Assert.AreEqual(Maybe<string>.Nothing, maybe);
 		}
 
 		[Test]
-		public void LookupNrtReturnsMaybeOfValueForKeyWhenValueExists()
+		public void LookupReturnsMaybeOfNrtValueForKeyWhenValueExists()
 		{
 			var dictionary = new Dictionary<string, string?>
 			{
 				["a"] = "b"
 			};
 
-			var maybe = dictionary.LookupNrt("a");
+			var maybe = dictionary.Lookup<string, string?, string>("a");
 
 			Assert.AreEqual("b".ToMaybe(), maybe);
 		}

--- a/Functional.Maybe.NTests/MaybeDictionaryTests.cs
+++ b/Functional.Maybe.NTests/MaybeDictionaryTests.cs
@@ -1,9 +1,9 @@
 ﻿using System.Collections.Generic;
 using NUnit.Framework;
 
-namespace Functional.Maybe.NTests
+namespace Functional.Maybe.Tests
 {
-  class MaybeDictionaryNrtTests
+  class MaybeDictionaryTests
   {
     [Test]
     public void METHOD1() //bug

--- a/Functional.Maybe.NTests/MaybeDictionaryTests.cs
+++ b/Functional.Maybe.NTests/MaybeDictionaryTests.cs
@@ -6,7 +6,7 @@ namespace Functional.Maybe.Tests
   class MaybeDictionaryTests
   {
     [Test]
-    public void METHOD1() //bug
+    public void LookupNrtReturnsNothingWhenThereIsNoValueForKey()
     {
       var dictionary = new Dictionary<string, string?>();
 
@@ -16,7 +16,7 @@ namespace Functional.Maybe.Tests
     }
 
     [Test]
-    public void METHOD2() //bug
+    public void LookupNrtReturnsNothingWhenValueForKeyIsNull()
     {
       var dictionary = new Dictionary<string, string?>
       {
@@ -29,7 +29,7 @@ namespace Functional.Maybe.Tests
     }
 
     [Test]
-    public void METHOD3() //bug
+    public void LookupNrtReturnsMaybeOfValueForKeyWhenValueExists()
     {
       var dictionary = new Dictionary<string, string?>
       {

--- a/Functional.Maybe.NTests/MaybeDictionaryTests.cs
+++ b/Functional.Maybe.NTests/MaybeDictionaryTests.cs
@@ -3,42 +3,42 @@ using NUnit.Framework;
 
 namespace Functional.Maybe.Tests
 {
-  class MaybeDictionaryTests
-  {
-    [Test]
-    public void LookupNrtReturnsNothingWhenThereIsNoValueForKey()
-    {
-      var dictionary = new Dictionary<string, string?>();
+	class MaybeDictionaryTests
+	{
+		[Test]
+		public void LookupNrtReturnsNothingWhenThereIsNoValueForKey()
+		{
+			var dictionary = new Dictionary<string, string?>();
 
-      var maybe = dictionary.LookupNrt("a");
+			var maybe = dictionary.LookupNrt("a");
 
-      Assert.AreEqual(Maybe<string>.Nothing, maybe);
-    }
+			Assert.AreEqual(Maybe<string>.Nothing, maybe);
+		}
 
-    [Test]
-    public void LookupNrtReturnsNothingWhenValueForKeyIsNull()
-    {
-      var dictionary = new Dictionary<string, string?>
-      {
-        ["a"] = null
-      };
+		[Test]
+		public void LookupNrtReturnsNothingWhenValueForKeyIsNull()
+		{
+			var dictionary = new Dictionary<string, string?>
+			{
+				["a"] = null
+			};
 
-      var maybe = dictionary.LookupNrt("a");
+			var maybe = dictionary.LookupNrt("a");
 
-      Assert.AreEqual(Maybe<string>.Nothing, maybe);
-    }
+			Assert.AreEqual(Maybe<string>.Nothing, maybe);
+		}
 
-    [Test]
-    public void LookupNrtReturnsMaybeOfValueForKeyWhenValueExists()
-    {
-      var dictionary = new Dictionary<string, string?>
-      {
-        ["a"] = "b"
-      };
+		[Test]
+		public void LookupNrtReturnsMaybeOfValueForKeyWhenValueExists()
+		{
+			var dictionary = new Dictionary<string, string?>
+			{
+				["a"] = "b"
+			};
 
-      var maybe = dictionary.LookupNrt("a");
+			var maybe = dictionary.LookupNrt("a");
 
-      Assert.AreEqual("b".ToMaybe(), maybe);
-    }
-  }
+			Assert.AreEqual("b".ToMaybe(), maybe);
+		}
+	}
 }

--- a/Functional.Maybe.NTests/MaybeEnumerableTests.cs
+++ b/Functional.Maybe.NTests/MaybeEnumerableTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using NUnit.Framework;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace Functional.Maybe.Tests
 {
@@ -172,6 +173,29 @@ namespace Functional.Maybe.Tests
 		}
 
 		[Test]
+		public void SingleMaybe_WhenSubtypeSpecified_ReturnsDowncastedItem()
+		{
+			var collection = new object[] { "3", 2 };
+			var itemToSearch = "3";
+
+			var maybe = collection.SingleMaybe<object, string>(i => i.Equals(itemToSearch));
+
+			Assert.IsTrue(maybe.IsSomething());
+			Assert.AreEqual(itemToSearch, maybe.Value);
+		}
+
+		[Test]
+		public void SingleMaybe_WhenWrongSubtypeIsSpecified_ReturnsNothing()
+		{
+			var collection = new object[] { "3", 2 };
+			var itemToSearch = "3";
+
+			var maybe = collection.SingleMaybe<object, Regex>(i => i.Equals(itemToSearch));
+
+			Assert.IsTrue(maybe.IsNothing());
+		}
+
+		[Test]
 		public void LastMaybe_WhenCalledOnEmptyEnumerable_ReturnsNothing()
 		{
 			var maybe = Enumerable.Empty<object>().LastMaybe();
@@ -210,7 +234,7 @@ namespace Functional.Maybe.Tests
 		}
 
 		[Test]
-		public void FromMaybeNrt_WhenInvokedOnNothingOfEnumerableOfNrts_ReturnsEmptyEnumerableOfNrts()
+		public void FromMaybe_WhenInvokedOnNothingOfEnumerableOfNrts_ReturnsEmptyEnumerableOfNrts()
 		{
 			var maybe = Maybe<IEnumerable<string?>>.Nothing;
 
@@ -220,7 +244,7 @@ namespace Functional.Maybe.Tests
 		}
 
 		[Test]
-		public void FromMaybeNrt_WhenInvokedOnMaybeOfEmptyEnumerableOfNrts_ReturnsEmptyEnumerableOfNrts()
+		public void FromMaybe_WhenInvokedOnMaybeOfEmptyEnumerableOfNrts_ReturnsEmptyEnumerableOfNrts()
 		{
 			var maybe = new List<string?>().ToMaybe<IEnumerable<string?>>();
 

--- a/Functional.Maybe.NTests/MaybeEnumerableTests.cs
+++ b/Functional.Maybe.NTests/MaybeEnumerableTests.cs
@@ -5,228 +5,228 @@ using System.Linq;
 
 namespace Functional.Maybe.Tests
 {
-  [TestFixture]
-  public class MaybeEnumerableTests
-  {
-    [Test]
-    public void WhereValueExist_Should_remove_Nothing_values()
-    {
-      var sequence = new[] { 1.ToMaybe(), Maybe<int>.Nothing, 2.ToMaybe() };
-      int[] expected = { 1, 2 };
+	[TestFixture]
+	public class MaybeEnumerableTests
+	{
+		[Test]
+		public void WhereValueExist_Should_remove_Nothing_values()
+		{
+			var sequence = new[] { 1.ToMaybe(), Maybe<int>.Nothing, 2.ToMaybe() };
+			int[] expected = { 1, 2 };
 
-      var actual = sequence.WhereValueExist().ToArray();
+			var actual = sequence.WhereValueExist().ToArray();
 
-      Assert.AreEqual(expected.Length, actual.Length);
-      for (int i = 0; i < expected.Length; i++)
-      {
-        Assert.AreEqual(expected[i], actual[i]);
-      }
-    }
+			Assert.AreEqual(expected.Length, actual.Length);
+			for (int i = 0; i < expected.Length; i++)
+			{
+				Assert.AreEqual(expected[i], actual[i]);
+			}
+		}
 
-    [Test]
-    public void SelectWhereValueExist_Should_work_with_null_returned_from_transformation()
-    {
-      var sequence = new[] { "a".ToMaybe(), "b".ToMaybe(), "c".ToMaybe() };
-      var expected = new string?[] { null, null, null };
+		[Test]
+		public void SelectWhereValueExist_Should_work_with_null_returned_from_transformation()
+		{
+			var sequence = new[] { "a".ToMaybe(), "b".ToMaybe(), "c".ToMaybe() };
+			var expected = new string?[] { null, null, null };
 
-      string?[] actual = sequence.SelectWhereValueExist<string, string?>(s => null).ToArray();
+			string?[] actual = sequence.SelectWhereValueExist<string, string?>(s => null).ToArray();
 
-      CollectionAssert.AreEqual(expected, actual);
-    }
+			CollectionAssert.AreEqual(expected, actual);
+		}
 
-    [Test]
-    public void Given_ThreeSome_UnionReturnsCollectionOfAll()
-    {
-      var one = 1.ToMaybe();
-      var two = 2.ToMaybe();
-      var three = 3.ToMaybe();
+		[Test]
+		public void Given_ThreeSome_UnionReturnsCollectionOfAll()
+		{
+			var one = 1.ToMaybe();
+			var two = 2.ToMaybe();
+			var three = 3.ToMaybe();
 
-      var res = one.Union(two, three);
-      Assert.AreEqual(3, res.Count());
-      Assert.IsTrue(res.SequenceEqual(new[] { 1, 2, 3 }));
-    }
+			var res = one.Union(two, three);
+			Assert.AreEqual(3, res.Count());
+			Assert.IsTrue(res.SequenceEqual(new[] { 1, 2, 3 }));
+		}
 
-    [Test]
-    public void Given_EnumerableOfMaybes_SelectShouldWorkWithNullValues()
-    {
-      var enumerable = new[] { "a".ToMaybe(), "b".ToMaybe(), "c".ToMaybe() };
+		[Test]
+		public void Given_EnumerableOfMaybes_SelectShouldWorkWithNullValues()
+		{
+			var enumerable = new[] { "a".ToMaybe(), "b".ToMaybe(), "c".ToMaybe() };
 
-      var results = enumerable.Select<string, string>(s => null);
+			var results = enumerable.Select<string, string>(s => null);
 
-      CollectionAssert.AreEqual(new[]
-      {
-        Maybe<string>.Nothing,
-        Maybe<string>.Nothing,
-        Maybe<string>.Nothing,
-      }, results);
-    }
+			CollectionAssert.AreEqual(new[]
+			{
+				Maybe<string>.Nothing,
+				Maybe<string>.Nothing,
+				Maybe<string>.Nothing,
+			}, results);
+		}
 
-    [Test]
-    public void Given_OneSome_UnionReturnsCollectionOfOne()
-    {
-      var one = 1.ToMaybe();
-      var two = Maybe<int>.Nothing;
+		[Test]
+		public void Given_OneSome_UnionReturnsCollectionOfOne()
+		{
+			var one = 1.ToMaybe();
+			var two = Maybe<int>.Nothing;
 
-      var res = one.Union(two);
-      Assert.AreEqual(1, res.Count());
-      Assert.IsTrue(res.SequenceEqual(new[] { 1 }));
-    }
+			var res = one.Union(two);
+			Assert.AreEqual(1, res.Count());
+			Assert.IsTrue(res.SequenceEqual(new[] { 1 }));
+		}
 
-    [Test]
-    public void Given_CollectionAndSome_UnionReturnsCollectionPlusSome()
-    {
-      var one = new[] { 1, 3 };
-      var two = 2.ToMaybe();
+		[Test]
+		public void Given_CollectionAndSome_UnionReturnsCollectionPlusSome()
+		{
+			var one = new[] { 1, 3 };
+			var two = 2.ToMaybe();
 
-      var res = one.Union(two);
-      Assert.AreEqual(3, res.Count());
-      Assert.IsTrue(res.SequenceEqual(new[] { 1, 3, 2 }));
-    }
+			var res = one.Union(two);
+			Assert.AreEqual(3, res.Count());
+			Assert.IsTrue(res.SequenceEqual(new[] { 1, 3, 2 }));
+		}
 
-    [Test]
-    public void FirstMaybe_WhenCalledOnEmptyEnumerable_ReturnsNothing()
-    {
-      var maybe = Enumerable.Empty<object>().FirstMaybe();
+		[Test]
+		public void FirstMaybe_WhenCalledOnEmptyEnumerable_ReturnsNothing()
+		{
+			var maybe = Enumerable.Empty<object>().FirstMaybe();
 
-      Assert.IsTrue(maybe.IsNothing());
-    }
+			Assert.IsTrue(maybe.IsNothing());
+		}
 
-    [Test]
-    public void FirstMaybe_WhenCalledOnEmptyEnumerableOfNrts_ReturnsNothing()
-    {
-      var maybe = Enumerable.Empty<object?>().FirstMaybe();
+		[Test]
+		public void FirstMaybe_WhenCalledOnEmptyEnumerableOfNrts_ReturnsNothing()
+		{
+			var maybe = Enumerable.Empty<object?>().FirstMaybe();
 
-      Assert.IsTrue(maybe.IsNothing());
-    }
+			Assert.IsTrue(maybe.IsNothing());
+		}
 
-    [Test]
-    public void FirstMaybe_WhenCalledOnEnumerableWithNoMatches_ReturnsNothing()
-    {
-      var collection = new[] { 1, 2 };
-      var itemToSearch = 3;
+		[Test]
+		public void FirstMaybe_WhenCalledOnEnumerableWithNoMatches_ReturnsNothing()
+		{
+			var collection = new[] { 1, 2 };
+			var itemToSearch = 3;
 
-      var maybe = collection.FirstMaybe(i => i == itemToSearch);
+			var maybe = collection.FirstMaybe(i => i == itemToSearch);
 
-      Assert.IsTrue(maybe.IsNothing());
-    }
+			Assert.IsTrue(maybe.IsNothing());
+		}
 
-    [Test]
-    public void FirstMaybe_WhenCalledOnEnumerableWithMatches_ReturnsFirstMatchingElement()
-    {
-      var expectedItem = Tuple.Create(2);
-      var collection = new[]
-      {
-        Tuple.Create(1),
-        expectedItem, // first matching element
-        Tuple.Create(2), // last matching element
-        Tuple.Create(3)
-      };
+		[Test]
+		public void FirstMaybe_WhenCalledOnEnumerableWithMatches_ReturnsFirstMatchingElement()
+		{
+			var expectedItem = Tuple.Create(2);
+			var collection = new[]
+			{
+				Tuple.Create(1),
+				expectedItem, // first matching element
+				Tuple.Create(2), // last matching element
+				Tuple.Create(3)
+			};
 
-      var maybe = collection.FirstMaybe (i => i.Item1 == 2);
+			var maybe = collection.FirstMaybe (i => i.Item1 == 2);
 
-      Assert.IsTrue(maybe.IsSomething());
-      // use AreSame to compare expected value with actual one by reference
-      Assert.AreSame(expectedItem, maybe.Value);
-    }
+			Assert.IsTrue(maybe.IsSomething());
+			// use AreSame to compare expected value with actual one by reference
+			Assert.AreSame(expectedItem, maybe.Value);
+		}
 
-    [Test]
-    public void SingleMaybe_WhenCalledOnEmptyEnumerable_ReturnsNothing()
-    {
-      var maybe = Enumerable.Empty<object>().SingleMaybe();
+		[Test]
+		public void SingleMaybe_WhenCalledOnEmptyEnumerable_ReturnsNothing()
+		{
+			var maybe = Enumerable.Empty<object>().SingleMaybe();
 
-      Assert.IsTrue(maybe.IsNothing());
-    }
+			Assert.IsTrue(maybe.IsNothing());
+		}
 
-    [Test]
-    public void SingleMaybe_WhenCalledOnEnumerableWithNoMatches_ReturnsNothing()
-    {
-      var collection = new[] { 1, 2 };
-      var itemToSearch = 3;
+		[Test]
+		public void SingleMaybe_WhenCalledOnEnumerableWithNoMatches_ReturnsNothing()
+		{
+			var collection = new[] { 1, 2 };
+			var itemToSearch = 3;
 
-      var maybe = collection.SingleMaybe(i => i == itemToSearch);
+			var maybe = collection.SingleMaybe(i => i == itemToSearch);
 
-      Assert.IsTrue(maybe.IsNothing());
-    }
+			Assert.IsTrue(maybe.IsNothing());
+		}
 
-    [Test]
-    public void SingleMaybe_WhenCalledOnNonEmptyEnumerableWithMultipleMatches_ReturnsNothing()
-    {
-      var collection = new[] { 1, 1, 2 };
-      var itemToSearch = 1;
+		[Test]
+		public void SingleMaybe_WhenCalledOnNonEmptyEnumerableWithMultipleMatches_ReturnsNothing()
+		{
+			var collection = new[] { 1, 1, 2 };
+			var itemToSearch = 1;
 
-      var maybe = collection.SingleMaybe(i => i == itemToSearch);
+			var maybe = collection.SingleMaybe(i => i == itemToSearch);
 
-      Assert.IsTrue(maybe.IsNothing());
-    }
+			Assert.IsTrue(maybe.IsNothing());
+		}
 
-    [Test]
-    public void SingleMaybe_WhenCalledOnNonEmptyEnumerableWithSingleMatch_ReturnsSingleMatchingElement()
-    {
-      var collection = new[] { 1, 2, 3 };
-      var itemToSearch = 2;
+		[Test]
+		public void SingleMaybe_WhenCalledOnNonEmptyEnumerableWithSingleMatch_ReturnsSingleMatchingElement()
+		{
+			var collection = new[] { 1, 2, 3 };
+			var itemToSearch = 2;
 
-      var maybe = collection.SingleMaybe(i => i == itemToSearch);
+			var maybe = collection.SingleMaybe(i => i == itemToSearch);
 
-      Assert.IsTrue(maybe.IsSomething());
-      Assert.AreEqual(itemToSearch, maybe.Value);
-    }
+			Assert.IsTrue(maybe.IsSomething());
+			Assert.AreEqual(itemToSearch, maybe.Value);
+		}
 
-    [Test]
-    public void LastMaybe_WhenCalledOnEmptyEnumerable_ReturnsNothing()
-    {
-      var maybe = Enumerable.Empty<object>().LastMaybe();
+		[Test]
+		public void LastMaybe_WhenCalledOnEmptyEnumerable_ReturnsNothing()
+		{
+			var maybe = Enumerable.Empty<object>().LastMaybe();
 
-      Assert.IsTrue(maybe.IsNothing());
-    }
+			Assert.IsTrue(maybe.IsNothing());
+		}
 
-    [Test]
-    public void LastMaybe_WhenCalledOnEnumerableWithNoMatches_ReturnsNothing()
-    {
-      var collection = new[] { 1, 2 };
-      var itemToSearch = 3;
+		[Test]
+		public void LastMaybe_WhenCalledOnEnumerableWithNoMatches_ReturnsNothing()
+		{
+			var collection = new[] { 1, 2 };
+			var itemToSearch = 3;
 
-      var maybe = collection.LastMaybe(i => i == itemToSearch);
+			var maybe = collection.LastMaybe(i => i == itemToSearch);
 
-      Assert.IsTrue(maybe.IsNothing());
-    }
+			Assert.IsTrue(maybe.IsNothing());
+		}
 
-    [Test]
-    public void LastMaybe_WhenCalledOnEnumerableWithMatches_ReturnsLastMatchingElement()
-    {
-      var expectedItem = Tuple.Create(2);
-      var collection = new[]
-      {
-        Tuple.Create(1),
-        Tuple.Create(2), // first matching element
-        expectedItem, // last matching element
-        Tuple.Create(3)
-      };
+		[Test]
+		public void LastMaybe_WhenCalledOnEnumerableWithMatches_ReturnsLastMatchingElement()
+		{
+			var expectedItem = Tuple.Create(2);
+			var collection = new[]
+			{
+				Tuple.Create(1),
+				Tuple.Create(2), // first matching element
+				expectedItem, // last matching element
+				Tuple.Create(3)
+			};
 
-      var maybe = collection.LastMaybe(i => i.Item1 == 2);
+			var maybe = collection.LastMaybe(i => i.Item1 == 2);
 
-      Assert.IsTrue(maybe.IsSomething());
-      // use AreSame to compare expected value with actual one by reference
-      Assert.AreSame(expectedItem, maybe.Value);
-    }
+			Assert.IsTrue(maybe.IsSomething());
+			// use AreSame to compare expected value with actual one by reference
+			Assert.AreSame(expectedItem, maybe.Value);
+		}
 
-    [Test]
-    public void FromMaybeNrt_WhenInvokedOnNothingOfEnumerableOfNrts_ReturnsEmptyEnumerableOfNrts()
-    {
-      var maybe = Maybe<IEnumerable<string?>>.Nothing;
+		[Test]
+		public void FromMaybeNrt_WhenInvokedOnNothingOfEnumerableOfNrts_ReturnsEmptyEnumerableOfNrts()
+		{
+			var maybe = Maybe<IEnumerable<string?>>.Nothing;
 
-      IEnumerable<string?> result = maybe.FromMaybe();
+			IEnumerable<string?> result = maybe.FromMaybe();
 
-      CollectionAssert.IsEmpty(result);
-    }
+			CollectionAssert.IsEmpty(result);
+		}
 
-    [Test]
-    public void FromMaybeNrt_WhenInvokedOnMaybeOfEmptyEnumerableOfNrts_ReturnsEmptyEnumerableOfNrts()
-    {
-      var maybe = new List<string?>().ToMaybe<IEnumerable<string?>>();
+		[Test]
+		public void FromMaybeNrt_WhenInvokedOnMaybeOfEmptyEnumerableOfNrts_ReturnsEmptyEnumerableOfNrts()
+		{
+			var maybe = new List<string?>().ToMaybe<IEnumerable<string?>>();
 
-      IEnumerable<string?> result = maybe.FromMaybe();
+			IEnumerable<string?> result = maybe.FromMaybe();
 
-      CollectionAssert.IsEmpty(result);
-    }
-  }
+			CollectionAssert.IsEmpty(result);
+		}
+	}
 }

--- a/Functional.Maybe.NTests/MaybeEnumerableTests.cs
+++ b/Functional.Maybe.NTests/MaybeEnumerableTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using NUnit.Framework;
 using System.Linq;
 

--- a/Functional.Maybe.NTests/MaybeEnumerableTests.cs
+++ b/Functional.Maybe.NTests/MaybeEnumerableTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using NUnit.Framework;
 using System.Linq;
 
@@ -121,7 +122,7 @@ namespace Functional.Maybe.Tests
         Tuple.Create(3)
       };
 
-      var maybe = collection.FirstMaybe(i => i.Item1 == 2);
+      var maybe = collection.FirstMaybe (i => i.Item1 == 2);
 
       Assert.IsTrue(maybe.IsSomething());
       // use AreSame to compare expected value with actual one by reference
@@ -206,6 +207,26 @@ namespace Functional.Maybe.Tests
       Assert.IsTrue(maybe.IsSomething());
       // use AreSame to compare expected value with actual one by reference
       Assert.AreSame(expectedItem, maybe.Value);
+    }
+
+    [Test]
+    public void FromMaybeNrt_WhenXXXXXXXXXXXXXXX() //bug
+    {
+      var maybe = (null as IEnumerable<string?>).ToMaybe();
+
+      IEnumerable<string?> result = maybe.FromMaybe();
+
+      CollectionAssert.IsEmpty(result);
+    }
+
+    [Test]
+    public void FromMaybeNrt_WhenXXXXXXXXXXXXXXX2() //bug
+    {
+      var maybe = new List<string?>().ToMaybe<IEnumerable<string?>>();
+
+      IEnumerable<string?> result = maybe.FromMaybe();
+
+      CollectionAssert.IsEmpty(result);
     }
   }
 }

--- a/Functional.Maybe.NTests/MaybeEnumerableTests.cs
+++ b/Functional.Maybe.NTests/MaybeEnumerableTests.cs
@@ -92,9 +92,9 @@ namespace Functional.Maybe.Tests
     }
 
     [Test]
-    public void FirstMaybeNrt_WhenCalledOnEmptyEnumerable_ReturnsNothing()
+    public void FirstMaybe_WhenCalledOnEmptyEnumerableOfNrts_ReturnsNothing()
     {
-      var maybe = Enumerable.Empty<object?>().FirstMaybeNrt();
+      var maybe = Enumerable.Empty<object?>().FirstMaybe();
 
       Assert.IsTrue(maybe.IsNothing());
     }
@@ -132,7 +132,7 @@ namespace Functional.Maybe.Tests
     [Test]
     public void SingleMaybe_WhenCalledOnEmptyEnumerable_ReturnsNothing()
     {
-      var maybe = Enumerable.Empty<object>().SingleMaybeNrt();
+      var maybe = Enumerable.Empty<object>().SingleMaybe();
 
       Assert.IsTrue(maybe.IsNothing());
     }

--- a/Functional.Maybe.NTests/MaybeEnumerableTests.cs
+++ b/Functional.Maybe.NTests/MaybeEnumerableTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using NUnit.Framework;
 using System.Linq;
 
@@ -10,7 +11,7 @@ namespace Functional.Maybe.Tests
 		[Test]
 		public void WhereValueExist_Should_remove_Nothing_values()
 		{
-			var sequence = new Maybe<int>[] { 1.ToMaybe(), Maybe<int>.Nothing, 2.ToMaybe() };
+			var sequence = new[] { 1.ToMaybe(), Maybe<int>.Nothing, 2.ToMaybe() };
 			int[] expected = { 1, 2 };
 
 			var actual = sequence.WhereValueExist().ToArray();
@@ -23,6 +24,17 @@ namespace Functional.Maybe.Tests
 		}
 
 		[Test]
+		public void SelectWhereValueExist_Should_work_with_null_returned_from_transformation()
+		{
+			var sequence = new[] { "a".ToMaybe(), "b".ToMaybe(), "c".ToMaybe() };
+			var expected = new string?[] { null, null, null };
+
+			string?[] actual = sequence.SelectWhereValueExist<string, string?>(s => null).ToArray();
+
+			CollectionAssert.AreEqual(expected, actual);
+		}
+
+		[Test]
 		public void Given_ThreeSome_UnionReturnsCollectionOfAll()
 		{
 			var one = 1.ToMaybe();
@@ -32,6 +44,21 @@ namespace Functional.Maybe.Tests
 			var res = one.Union(two, three);
 			Assert.AreEqual(3, res.Count());
 			Assert.IsTrue(res.SequenceEqual(new[] { 1, 2, 3 }));
+		}
+
+		[Test]
+		public void Given_EnumerableOfMaybes_SelectShouldWorkWithNullValues()
+		{
+			var enumerable = new[] { "a".ToMaybe(), "b".ToMaybe(), "c".ToMaybe() };
+
+			var results = enumerable.Select<string, string>(s => null);
+
+			CollectionAssert.AreEqual(new []
+			{
+				Maybe<string>.Nothing,
+				Maybe<string>.Nothing,
+				Maybe<string>.Nothing,
+			}, results);
 		}
 
 		[Test]
@@ -56,7 +83,7 @@ namespace Functional.Maybe.Tests
 			Assert.IsTrue(res.SequenceEqual(new[] { 1, 3, 2 }));
 		}
 
-       [Test]
+      [Test]
 	    public void FirstMaybe_WhenCalledOnEmptyEnumerable_ReturnsNothing()
         {
             var maybe = Enumerable.Empty<object>().FirstMaybe();
@@ -174,4 +201,34 @@ namespace Functional.Maybe.Tests
             Assert.AreSame(expectedItem, maybe.Value);
         }
     }
+
+	class C1
+	{
+		[Test]
+		public void METHOD()
+		{
+			Dictionary<string, string?> d = new Dictionary<string, string>();
+
+			var lookupValue1 = Lookup<string, string, Dictionary<string, string?>>(new Dictionary<string, string?>(), "a");
+			var lookupValue2 = Lookup<string, string, Dictionary<string, string>>(new Dictionary<string, string>(), "a");
+		}
+
+		public LookupValue<TV> Lookup<TK, TV, TD, TDV>(TD d, TK key) 
+			where TK : notnull
+			where TV : notnull
+			where TDV : TV
+			where TD : Dictionary<TK, TDV>
+		{
+			if (d.TryGetValue(key, out var result))
+			{
+				return new LookupValue<TV>(result);
+			}
+			else
+			{
+				return new LookupValue<TV>(default);
+			}
+		}
+
+		public record LookupValue<T>(T? Value) where T : notnull;
+	}
 }

--- a/Functional.Maybe.NTests/MaybeEnumerableTests.cs
+++ b/Functional.Maybe.NTests/MaybeEnumerableTests.cs
@@ -210,9 +210,9 @@ namespace Functional.Maybe.Tests
     }
 
     [Test]
-    public void FromMaybeNrt_WhenXXXXXXXXXXXXXXX() //bug
+    public void FromMaybeNrt_WhenInvokedOnNothingOfEnumerableOfNrts_ReturnsEmptyEnumerableOfNrts()
     {
-      var maybe = (null as IEnumerable<string?>).ToMaybe();
+      var maybe = Maybe<IEnumerable<string?>>.Nothing;
 
       IEnumerable<string?> result = maybe.FromMaybe();
 
@@ -220,7 +220,7 @@ namespace Functional.Maybe.Tests
     }
 
     [Test]
-    public void FromMaybeNrt_WhenXXXXXXXXXXXXXXX2() //bug
+    public void FromMaybeNrt_WhenInvokedOnMaybeOfEmptyEnumerableOfNrts_ReturnsEmptyEnumerableOfNrts()
     {
       var maybe = new List<string?>().ToMaybe<IEnumerable<string?>>();
 

--- a/Functional.Maybe.NTests/MaybeEnumerableTests.cs
+++ b/Functional.Maybe.NTests/MaybeEnumerableTests.cs
@@ -5,230 +5,208 @@ using System.Linq;
 
 namespace Functional.Maybe.Tests
 {
-	[TestFixture]
-	public class MaybeEnumerableTests
-	{
-		[Test]
-		public void WhereValueExist_Should_remove_Nothing_values()
-		{
-			var sequence = new[] { 1.ToMaybe(), Maybe<int>.Nothing, 2.ToMaybe() };
-			int[] expected = { 1, 2 };
+  [TestFixture]
+  public class MaybeEnumerableTests
+  {
+    [Test]
+    public void WhereValueExist_Should_remove_Nothing_values()
+    {
+      var sequence = new[] { 1.ToMaybe(), Maybe<int>.Nothing, 2.ToMaybe() };
+      int[] expected = { 1, 2 };
 
-			var actual = sequence.WhereValueExist().ToArray();
+      var actual = sequence.WhereValueExist().ToArray();
 
-			Assert.AreEqual(expected.Length, actual.Length);
-			for (int i = 0; i < expected.Length; i++)
-			{
-				Assert.AreEqual(expected[i], actual[i]);
-			}
-		}
-
-		[Test]
-		public void SelectWhereValueExist_Should_work_with_null_returned_from_transformation()
-		{
-			var sequence = new[] { "a".ToMaybe(), "b".ToMaybe(), "c".ToMaybe() };
-			var expected = new string?[] { null, null, null };
-
-			string?[] actual = sequence.SelectWhereValueExist<string, string?>(s => null).ToArray();
-
-			CollectionAssert.AreEqual(expected, actual);
-		}
-
-		[Test]
-		public void Given_ThreeSome_UnionReturnsCollectionOfAll()
-		{
-			var one = 1.ToMaybe();
-			var two = 2.ToMaybe();
-			var three = 3.ToMaybe();
-
-			var res = one.Union(two, three);
-			Assert.AreEqual(3, res.Count());
-			Assert.IsTrue(res.SequenceEqual(new[] { 1, 2, 3 }));
-		}
-
-		[Test]
-		public void Given_EnumerableOfMaybes_SelectShouldWorkWithNullValues()
-		{
-			var enumerable = new[] { "a".ToMaybe(), "b".ToMaybe(), "c".ToMaybe() };
-
-			var results = enumerable.Select<string, string>(s => null);
-
-			CollectionAssert.AreEqual(new []
-			{
-				Maybe<string>.Nothing,
-				Maybe<string>.Nothing,
-				Maybe<string>.Nothing,
-			}, results);
-		}
-
-		[Test]
-		public void Given_OneSome_UnionReturnsCollectionOfOne()
-		{
-			var one = 1.ToMaybe();
-			var two = Maybe<int>.Nothing;
-
-			var res = one.Union(two);
-			Assert.AreEqual(1, res.Count());
-			Assert.IsTrue(res.SequenceEqual(new[] { 1 }));
-		}
-
-		[Test]
-		public void Given_CollectionAndSome_UnionReturnsCollectionPlusSome()
-		{
-			var one = new[] { 1, 3 };
-			var two = 2.ToMaybe();
-
-			var res = one.Union(two);
-			Assert.AreEqual(3, res.Count());
-			Assert.IsTrue(res.SequenceEqual(new[] { 1, 3, 2 }));
-		}
-
-      [Test]
-	    public void FirstMaybe_WhenCalledOnEmptyEnumerable_ReturnsNothing()
-        {
-            var maybe = Enumerable.Empty<object>().FirstMaybe();
-
-            Assert.IsTrue(maybe.IsNothing());
-        }
-
-       [Test]
-        public void FirstMaybe_WhenCalledOnEnumerableWithNoMatches_ReturnsNothing()
-        {
-            var collection = new[] { 1, 2 };
-            var itemToSearch = 3;
-
-            var maybe = collection.FirstMaybe(i => i == itemToSearch);
-
-            Assert.IsTrue(maybe.IsNothing());
-        }
-
-       [Test]
-        public void FirstMaybe_WhenCalledOnEnumerableWithMatches_ReturnsFirstMatchingElement()
-        {
-            var expectedItem = Tuple.Create(2);
-            var collection = new[]
-            {
-                Tuple.Create(1),
-                expectedItem,    // first matching element
-                Tuple.Create(2), // last matching element
-                Tuple.Create(3)
-            };
-
-            var maybe = collection.FirstMaybe(i => i.Item1 == 2);
-
-            Assert.IsTrue(maybe.IsSomething());
-            // use AreSame to compare expected value with actual one by reference
-            Assert.AreSame(expectedItem, maybe.Value);
-        }
-
-       [Test]
-	    public void SingleMaybe_WhenCalledOnEmptyEnumerable_ReturnsNothing()
-	    {
-            var maybe = Enumerable.Empty<object>().SingleMaybe();
-
-            Assert.IsTrue(maybe.IsNothing());
-        }
-
-       [Test]
-        public void SingleMaybe_WhenCalledOnEnumerableWithNoMatches_ReturnsNothing()
-        {
-            var collection = new[] { 1, 2 };
-            var itemToSearch = 3;
-
-            var maybe = collection.SingleMaybe(i => i == itemToSearch);
-
-            Assert.IsTrue(maybe.IsNothing());
-        }
-
-       [Test]
-        public void SingleMaybe_WhenCalledOnNonEmptyEnumerableWithMultipleMatches_ReturnsNothing()
-        {
-            var collection = new[] { 1, 1, 2 };
-            var itemToSearch = 1;
-
-            var maybe = collection.SingleMaybe(i => i == itemToSearch);
-
-            Assert.IsTrue(maybe.IsNothing());
-        }
-
-       [Test]
-        public void SingleMaybe_WhenCalledOnNonEmptyEnumerableWithSingleMatch_ReturnsSingleMatchingElement()
-        {
-            var collection = new[] { 1, 2, 3 };
-            var itemToSearch = 2;
-
-            var maybe = collection.SingleMaybe(i => i == itemToSearch);
-
-            Assert.IsTrue(maybe.IsSomething());
-            Assert.AreEqual(itemToSearch, maybe.Value);
-        }
-
-       [Test]
-        public void LastMaybe_WhenCalledOnEmptyEnumerable_ReturnsNothing()
-        {
-            var maybe = Enumerable.Empty<object>().LastMaybe();
-
-            Assert.IsTrue(maybe.IsNothing());
-        }
-
-       [Test]
-        public void LastMaybe_WhenCalledOnEnumerableWithNoMatches_ReturnsNothing()
-        {
-            var collection = new[] { 1, 2 };
-            var itemToSearch = 3;
-
-            var maybe = collection.LastMaybe(i => i == itemToSearch);
-
-            Assert.IsTrue(maybe.IsNothing());
-        }
-
-       [Test]
-        public void LastMaybe_WhenCalledOnEnumerableWithMatches_ReturnsLastMatchingElement()
-        {
-            var expectedItem = Tuple.Create(2);
-            var collection = new[]
-            {
-                Tuple.Create(1),
-                Tuple.Create(2), // first matching element
-                expectedItem,    // last matching element
-                Tuple.Create(3)
-            };
-
-            var maybe = collection.LastMaybe(i => i.Item1 == 2);
-
-            Assert.IsTrue(maybe.IsSomething());
-            // use AreSame to compare expected value with actual one by reference
-            Assert.AreSame(expectedItem, maybe.Value);
-        }
+      Assert.AreEqual(expected.Length, actual.Length);
+      for (int i = 0; i < expected.Length; i++)
+      {
+        Assert.AreEqual(expected[i], actual[i]);
+      }
     }
 
-	class C1
-	{
-		[Test]
-		public void METHOD()
-		{
-			Dictionary<string, string?> d = new Dictionary<string, string>();
+    [Test]
+    public void SelectWhereValueExist_Should_work_with_null_returned_from_transformation()
+    {
+      var sequence = new[] { "a".ToMaybe(), "b".ToMaybe(), "c".ToMaybe() };
+      var expected = new string?[] { null, null, null };
 
-			var lookupValue1 = Lookup<string, string, Dictionary<string, string?>>(new Dictionary<string, string?>(), "a");
-			var lookupValue2 = Lookup<string, string, Dictionary<string, string>>(new Dictionary<string, string>(), "a");
-		}
+      string?[] actual = sequence.SelectWhereValueExist<string, string?>(s => null).ToArray();
 
-		public LookupValue<TV> Lookup<TK, TV, TD, TDV>(TD d, TK key) 
-			where TK : notnull
-			where TV : notnull
-			where TDV : TV
-			where TD : Dictionary<TK, TDV>
-		{
-			if (d.TryGetValue(key, out var result))
-			{
-				return new LookupValue<TV>(result);
-			}
-			else
-			{
-				return new LookupValue<TV>(default);
-			}
-		}
+      CollectionAssert.AreEqual(expected, actual);
+    }
 
-		public record LookupValue<T>(T? Value) where T : notnull;
-	}
+    [Test]
+    public void Given_ThreeSome_UnionReturnsCollectionOfAll()
+    {
+      var one = 1.ToMaybe();
+      var two = 2.ToMaybe();
+      var three = 3.ToMaybe();
+
+      var res = one.Union(two, three);
+      Assert.AreEqual(3, res.Count());
+      Assert.IsTrue(res.SequenceEqual(new[] { 1, 2, 3 }));
+    }
+
+    [Test]
+    public void Given_EnumerableOfMaybes_SelectShouldWorkWithNullValues()
+    {
+      var enumerable = new[] { "a".ToMaybe(), "b".ToMaybe(), "c".ToMaybe() };
+
+      var results = enumerable.Select<string, string>(s => null);
+
+      CollectionAssert.AreEqual(new[]
+      {
+        Maybe<string>.Nothing,
+        Maybe<string>.Nothing,
+        Maybe<string>.Nothing,
+      }, results);
+    }
+
+    [Test]
+    public void Given_OneSome_UnionReturnsCollectionOfOne()
+    {
+      var one = 1.ToMaybe();
+      var two = Maybe<int>.Nothing;
+
+      var res = one.Union(two);
+      Assert.AreEqual(1, res.Count());
+      Assert.IsTrue(res.SequenceEqual(new[] { 1 }));
+    }
+
+    [Test]
+    public void Given_CollectionAndSome_UnionReturnsCollectionPlusSome()
+    {
+      var one = new[] { 1, 3 };
+      var two = 2.ToMaybe();
+
+      var res = one.Union(two);
+      Assert.AreEqual(3, res.Count());
+      Assert.IsTrue(res.SequenceEqual(new[] { 1, 3, 2 }));
+    }
+
+    [Test]
+    public void FirstMaybe_WhenCalledOnEmptyEnumerable_ReturnsNothing()
+    {
+      var maybe = Enumerable.Empty<object>().FirstMaybe();
+
+      Assert.IsTrue(maybe.IsNothing());
+    }
+
+    [Test]
+    public void FirstMaybeNrt_WhenCalledOnEmptyEnumerable_ReturnsNothing()
+    {
+      var maybe = Enumerable.Empty<object?>().FirstMaybeNrt();
+
+      Assert.IsTrue(maybe.IsNothing());
+    }
+
+    [Test]
+    public void FirstMaybe_WhenCalledOnEnumerableWithNoMatches_ReturnsNothing()
+    {
+      var collection = new[] { 1, 2 };
+      var itemToSearch = 3;
+
+      var maybe = collection.FirstMaybe(i => i == itemToSearch);
+
+      Assert.IsTrue(maybe.IsNothing());
+    }
+
+    [Test]
+    public void FirstMaybe_WhenCalledOnEnumerableWithMatches_ReturnsFirstMatchingElement()
+    {
+      var expectedItem = Tuple.Create(2);
+      var collection = new[]
+      {
+        Tuple.Create(1),
+        expectedItem, // first matching element
+        Tuple.Create(2), // last matching element
+        Tuple.Create(3)
+      };
+
+      var maybe = collection.FirstMaybe(i => i.Item1 == 2);
+
+      Assert.IsTrue(maybe.IsSomething());
+      // use AreSame to compare expected value with actual one by reference
+      Assert.AreSame(expectedItem, maybe.Value);
+    }
+
+    [Test]
+    public void SingleMaybe_WhenCalledOnEmptyEnumerable_ReturnsNothing()
+    {
+      var maybe = Enumerable.Empty<object>().SingleMaybeNrt();
+
+      Assert.IsTrue(maybe.IsNothing());
+    }
+
+    [Test]
+    public void SingleMaybe_WhenCalledOnEnumerableWithNoMatches_ReturnsNothing()
+    {
+      var collection = new[] { 1, 2 };
+      var itemToSearch = 3;
+
+      var maybe = collection.SingleMaybe(i => i == itemToSearch);
+
+      Assert.IsTrue(maybe.IsNothing());
+    }
+
+    [Test]
+    public void SingleMaybe_WhenCalledOnNonEmptyEnumerableWithMultipleMatches_ReturnsNothing()
+    {
+      var collection = new[] { 1, 1, 2 };
+      var itemToSearch = 1;
+
+      var maybe = collection.SingleMaybe(i => i == itemToSearch);
+
+      Assert.IsTrue(maybe.IsNothing());
+    }
+
+    [Test]
+    public void SingleMaybe_WhenCalledOnNonEmptyEnumerableWithSingleMatch_ReturnsSingleMatchingElement()
+    {
+      var collection = new[] { 1, 2, 3 };
+      var itemToSearch = 2;
+
+      var maybe = collection.SingleMaybe(i => i == itemToSearch);
+
+      Assert.IsTrue(maybe.IsSomething());
+      Assert.AreEqual(itemToSearch, maybe.Value);
+    }
+
+    [Test]
+    public void LastMaybe_WhenCalledOnEmptyEnumerable_ReturnsNothing()
+    {
+      var maybe = Enumerable.Empty<object>().LastMaybe();
+
+      Assert.IsTrue(maybe.IsNothing());
+    }
+
+    [Test]
+    public void LastMaybe_WhenCalledOnEnumerableWithNoMatches_ReturnsNothing()
+    {
+      var collection = new[] { 1, 2 };
+      var itemToSearch = 3;
+
+      var maybe = collection.LastMaybe(i => i == itemToSearch);
+
+      Assert.IsTrue(maybe.IsNothing());
+    }
+
+    [Test]
+    public void LastMaybe_WhenCalledOnEnumerableWithMatches_ReturnsLastMatchingElement()
+    {
+      var expectedItem = Tuple.Create(2);
+      var collection = new[]
+      {
+        Tuple.Create(1),
+        Tuple.Create(2), // first matching element
+        expectedItem, // last matching element
+        Tuple.Create(3)
+      };
+
+      var maybe = collection.LastMaybe(i => i.Item1 == 2);
+
+      Assert.IsTrue(maybe.IsSomething());
+      // use AreSame to compare expected value with actual one by reference
+      Assert.AreSame(expectedItem, maybe.Value);
+    }
+  }
 }

--- a/Functional.Maybe.NTests/MaybeFunctionalWrappersTests.cs
+++ b/Functional.Maybe.NTests/MaybeFunctionalWrappersTests.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace Functional.Maybe.NTests
+{
+  class MaybeFunctionalWrappersTests
+  {
+    [Test]
+    public void METHOD1() //bug
+    {
+      var catcher = MaybeFunctionalWrappers
+        .CatcherNrt<string, string, Exception>(s => null);
+
+      var result = catcher("a");
+
+      Assert.AreEqual(Maybe<string>.Nothing, result);
+    }
+
+    [Test]
+    public void METHOD2() //bug
+    {
+      var catcher = MaybeFunctionalWrappers
+        .CatcherNrt<string, string, Exception>(s => 
+          throw new Exception());
+
+      var result = catcher("a");
+
+      Assert.AreEqual(Maybe<string>.Nothing, result);
+    }
+
+    [Test]
+    public void METHOD3() //bug
+    {
+      var catcher = MaybeFunctionalWrappers
+        .CatcherNrt<string, string, InvalidCastException>(
+          s => throw new Exception());
+
+      Assert.Throws<Exception>(() => catcher("a"));
+    }
+  }
+}

--- a/Functional.Maybe.NTests/MaybeFunctionalWrappersTests.cs
+++ b/Functional.Maybe.NTests/MaybeFunctionalWrappersTests.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using NUnit.Framework;
 
-namespace Functional.Maybe.NTests
+namespace Functional.Maybe.Tests
 {
   class MaybeFunctionalWrappersTests
   {

--- a/Functional.Maybe.NTests/MaybeFunctionalWrappersTests.cs
+++ b/Functional.Maybe.NTests/MaybeFunctionalWrappersTests.cs
@@ -50,7 +50,7 @@ namespace Functional.Maybe.Tests
     }
 
     [Test]
-    public void WrapCanProduceFuncWorkingCorrectlyWithNull()
+    public void WrapProducesFuncWorkingCorrectlyWithNullInput()
     {
       MaybeFunctionalWrappers.TryGet<string?, int> tryParse = int.TryParse;
       var wrapped = MaybeFunctionalWrappers.Wrap(tryParse);
@@ -61,7 +61,7 @@ namespace Functional.Maybe.Tests
     }
 
     [Test]
-    public void WrapNrtXXXXXXXx() //bug
+    public void WrapNrtProducesFuncWorkingCorrectlyWithNullOutput()
     {
       MaybeFunctionalWrappers.TryGet<string, string?> tryGetValue = 
           new Dictionary<string, string?>().TryGetValue;

--- a/Functional.Maybe.NTests/MaybeFunctionalWrappersTests.cs
+++ b/Functional.Maybe.NTests/MaybeFunctionalWrappersTests.cs
@@ -7,7 +7,7 @@ namespace Functional.Maybe.Tests
   class MaybeFunctionalWrappersTests
   {
     [Test]
-    public void METHOD1() //bug
+    public void CatcherNrtFromLambdaReturningNullReturnsNothing()
     {
       var catcher = MaybeFunctionalWrappers
         .CatcherNrt<string, string, Exception>(_ => null);
@@ -18,7 +18,7 @@ namespace Functional.Maybe.Tests
     }
 
     [Test]
-    public void METHOD2() //bug
+    public void CatcherNrtFromThrowingExpectedExceptionReturnsNothing()
     {
       var catcher = MaybeFunctionalWrappers
         .CatcherNrt<string, string, Exception>(
@@ -30,7 +30,7 @@ namespace Functional.Maybe.Tests
     }
 
     [Test]
-    public void METHOD3() //bug
+    public void CatcherNrtFromThrowingUnexpectedExceptionThrowsException()
     {
       var catcher = MaybeFunctionalWrappers
         .CatcherNrt<string, string, InvalidCastException>(
@@ -40,7 +40,7 @@ namespace Functional.Maybe.Tests
     }
 
     [Test]
-    public void METHOD4() //bug
+    public void CatcherNrtWorksWhenInvokedWithNull()
     {
       var catcher = MaybeFunctionalWrappers
         .CatcherNrt<string?, string, InvalidCastException>(
@@ -50,7 +50,7 @@ namespace Functional.Maybe.Tests
     }
 
     [Test]
-    public void METHOD5() //bug
+    public void WrapCanProduceFuncWorkingCorrectlyWithNull()
     {
       MaybeFunctionalWrappers.TryGet<string?, int> tryParse = int.TryParse;
       var wrapped = MaybeFunctionalWrappers.Wrap(tryParse);
@@ -61,7 +61,7 @@ namespace Functional.Maybe.Tests
     }
 
     [Test]
-    public void METHOD6() //bug
+    public void WrapNrtXXXXXXXx() //bug
     {
       MaybeFunctionalWrappers.TryGet<string, string?> tryGetValue = 
           new Dictionary<string, string?>().TryGetValue;

--- a/Functional.Maybe.NTests/MaybeFunctionalWrappersTests.cs
+++ b/Functional.Maybe.NTests/MaybeFunctionalWrappersTests.cs
@@ -7,10 +7,10 @@ namespace Functional.Maybe.Tests
 	class MaybeFunctionalWrappersTests
 	{
 		[Test]
-		public void CatcherNrtFromLambdaReturningNullReturnsNothing()
+		public void CatcherFromLambdaReturningNullReturnsNothing()
 		{
 			var catcher = MaybeFunctionalWrappers
-				.CatcherNrt<string, string, Exception>(_ => null);
+				.Catcher<string, string?, string, Exception>(_ => null);
 
 			var result = catcher("a");
 
@@ -18,10 +18,10 @@ namespace Functional.Maybe.Tests
 		}
 
 		[Test]
-		public void CatcherNrtFromThrowingExpectedExceptionReturnsNothing()
+		public void CatcherFromFuncThrowingExpectedExceptionReturnsNothing()
 		{
 			var catcher = MaybeFunctionalWrappers
-				.CatcherNrt<string, string, Exception>(
+				.Catcher<string, string?, string, Exception>(
 					_ => throw new Exception());
 
 			var result = catcher("a");
@@ -30,20 +30,20 @@ namespace Functional.Maybe.Tests
 		}
 
 		[Test]
-		public void CatcherNrtFromThrowingUnexpectedExceptionThrowsException()
+		public void CatcherFromThrowingUnexpectedExceptionThrowsException()
 		{
 			var catcher = MaybeFunctionalWrappers
-				.CatcherNrt<string, string, InvalidCastException>(
+				.Catcher<string, string?, string, InvalidCastException>(
 					_ => throw new Exception());
 
 			Assert.Throws<Exception>(() => catcher("a"));
 		}
 
 		[Test]
-		public void CatcherNrtWorksWhenInvokedWithNull()
+		public void CatcherWorksWhenInvokedWithNull()
 		{
 			var catcher = MaybeFunctionalWrappers
-				.CatcherNrt<string?, string, InvalidCastException>(
+				.Catcher<string?, string?, string, InvalidCastException>(
 					_ => throw new Exception());
 
 			Assert.Throws<Exception>(() => catcher(null));
@@ -61,11 +61,12 @@ namespace Functional.Maybe.Tests
 		}
 
 		[Test]
-		public void WrapNrtProducesFuncWorkingCorrectlyWithNullOutput()
+		public void WrapProducesFuncWorkingCorrectlyWithNullOutput()
 		{
 			MaybeFunctionalWrappers.TryGet<string, string?> tryGetValue = 
 				new Dictionary<string, string?>().TryGetValue;
-			var wrapped = MaybeFunctionalWrappers.WrapNrt(tryGetValue);
+			var wrapped = MaybeFunctionalWrappers
+				.Wrap<string, string?, string>(tryGetValue);
 
 			var result = wrapped("a");
 

--- a/Functional.Maybe.NTests/MaybeFunctionalWrappersTests.cs
+++ b/Functional.Maybe.NTests/MaybeFunctionalWrappersTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using NUnit.Framework;
 
 namespace Functional.Maybe.NTests
@@ -9,7 +10,7 @@ namespace Functional.Maybe.NTests
     public void METHOD1() //bug
     {
       var catcher = MaybeFunctionalWrappers
-        .CatcherNrt<string, string, Exception>(s => null);
+        .CatcherNrt<string, string, Exception>(_ => null);
 
       var result = catcher("a");
 
@@ -20,8 +21,8 @@ namespace Functional.Maybe.NTests
     public void METHOD2() //bug
     {
       var catcher = MaybeFunctionalWrappers
-        .CatcherNrt<string, string, Exception>(s => 
-          throw new Exception());
+        .CatcherNrt<string, string, Exception>(
+          _ => throw new Exception());
 
       var result = catcher("a");
 
@@ -33,9 +34,42 @@ namespace Functional.Maybe.NTests
     {
       var catcher = MaybeFunctionalWrappers
         .CatcherNrt<string, string, InvalidCastException>(
-          s => throw new Exception());
+          _ => throw new Exception());
 
       Assert.Throws<Exception>(() => catcher("a"));
+    }
+
+    [Test]
+    public void METHOD4() //bug
+    {
+      var catcher = MaybeFunctionalWrappers
+        .CatcherNrt<string?, string, InvalidCastException>(
+          _ => throw new Exception());
+
+      Assert.Throws<Exception>(() => catcher(null));
+    }
+
+    [Test]
+    public void METHOD5() //bug
+    {
+      MaybeFunctionalWrappers.TryGet<string?, int> tryParse = int.TryParse;
+      var wrapped = MaybeFunctionalWrappers.Wrap(tryParse);
+
+      var result = wrapped(null);
+
+      Assert.AreEqual(Maybe<int>.Nothing, result);
+    }
+
+    [Test]
+    public void METHOD6() //bug
+    {
+      MaybeFunctionalWrappers.TryGet<string, string?> tryGetValue = 
+          new Dictionary<string, string?>().TryGetValue;
+      var wrapped = MaybeFunctionalWrappers.WrapNrt(tryGetValue);
+
+      var result = wrapped("a");
+
+      Assert.AreEqual(Maybe<string>.Nothing, result);
     }
   }
 }

--- a/Functional.Maybe.NTests/MaybeFunctionalWrappersTests.cs
+++ b/Functional.Maybe.NTests/MaybeFunctionalWrappersTests.cs
@@ -4,72 +4,72 @@ using NUnit.Framework;
 
 namespace Functional.Maybe.Tests
 {
-  class MaybeFunctionalWrappersTests
-  {
-    [Test]
-    public void CatcherNrtFromLambdaReturningNullReturnsNothing()
-    {
-      var catcher = MaybeFunctionalWrappers
-        .CatcherNrt<string, string, Exception>(_ => null);
+	class MaybeFunctionalWrappersTests
+	{
+		[Test]
+		public void CatcherNrtFromLambdaReturningNullReturnsNothing()
+		{
+			var catcher = MaybeFunctionalWrappers
+				.CatcherNrt<string, string, Exception>(_ => null);
 
-      var result = catcher("a");
+			var result = catcher("a");
 
-      Assert.AreEqual(Maybe<string>.Nothing, result);
-    }
+			Assert.AreEqual(Maybe<string>.Nothing, result);
+		}
 
-    [Test]
-    public void CatcherNrtFromThrowingExpectedExceptionReturnsNothing()
-    {
-      var catcher = MaybeFunctionalWrappers
-        .CatcherNrt<string, string, Exception>(
-          _ => throw new Exception());
+		[Test]
+		public void CatcherNrtFromThrowingExpectedExceptionReturnsNothing()
+		{
+			var catcher = MaybeFunctionalWrappers
+				.CatcherNrt<string, string, Exception>(
+					_ => throw new Exception());
 
-      var result = catcher("a");
+			var result = catcher("a");
 
-      Assert.AreEqual(Maybe<string>.Nothing, result);
-    }
+			Assert.AreEqual(Maybe<string>.Nothing, result);
+		}
 
-    [Test]
-    public void CatcherNrtFromThrowingUnexpectedExceptionThrowsException()
-    {
-      var catcher = MaybeFunctionalWrappers
-        .CatcherNrt<string, string, InvalidCastException>(
-          _ => throw new Exception());
+		[Test]
+		public void CatcherNrtFromThrowingUnexpectedExceptionThrowsException()
+		{
+			var catcher = MaybeFunctionalWrappers
+				.CatcherNrt<string, string, InvalidCastException>(
+					_ => throw new Exception());
 
-      Assert.Throws<Exception>(() => catcher("a"));
-    }
+			Assert.Throws<Exception>(() => catcher("a"));
+		}
 
-    [Test]
-    public void CatcherNrtWorksWhenInvokedWithNull()
-    {
-      var catcher = MaybeFunctionalWrappers
-        .CatcherNrt<string?, string, InvalidCastException>(
-          _ => throw new Exception());
+		[Test]
+		public void CatcherNrtWorksWhenInvokedWithNull()
+		{
+			var catcher = MaybeFunctionalWrappers
+				.CatcherNrt<string?, string, InvalidCastException>(
+					_ => throw new Exception());
 
-      Assert.Throws<Exception>(() => catcher(null));
-    }
+			Assert.Throws<Exception>(() => catcher(null));
+		}
 
-    [Test]
-    public void WrapProducesFuncWorkingCorrectlyWithNullInput()
-    {
-      MaybeFunctionalWrappers.TryGet<string?, int> tryParse = int.TryParse;
-      var wrapped = MaybeFunctionalWrappers.Wrap(tryParse);
+		[Test]
+		public void WrapProducesFuncWorkingCorrectlyWithNullInput()
+		{
+			MaybeFunctionalWrappers.TryGet<string?, int> tryParse = int.TryParse;
+			var wrapped = MaybeFunctionalWrappers.Wrap(tryParse);
 
-      var result = wrapped(null);
+			var result = wrapped(null);
 
-      Assert.AreEqual(Maybe<int>.Nothing, result);
-    }
+			Assert.AreEqual(Maybe<int>.Nothing, result);
+		}
 
-    [Test]
-    public void WrapNrtProducesFuncWorkingCorrectlyWithNullOutput()
-    {
-      MaybeFunctionalWrappers.TryGet<string, string?> tryGetValue = 
-          new Dictionary<string, string?>().TryGetValue;
-      var wrapped = MaybeFunctionalWrappers.WrapNrt(tryGetValue);
+		[Test]
+		public void WrapNrtProducesFuncWorkingCorrectlyWithNullOutput()
+		{
+			MaybeFunctionalWrappers.TryGet<string, string?> tryGetValue = 
+				new Dictionary<string, string?>().TryGetValue;
+			var wrapped = MaybeFunctionalWrappers.WrapNrt(tryGetValue);
 
-      var result = wrapped("a");
+			var result = wrapped("a");
 
-      Assert.AreEqual(Maybe<string>.Nothing, result);
-    }
-  }
+			Assert.AreEqual(Maybe<string>.Nothing, result);
+		}
+	}
 }

--- a/Functional.Maybe.NTests/MaybeLinqTests.cs
+++ b/Functional.Maybe.NTests/MaybeLinqTests.cs
@@ -1,0 +1,41 @@
+﻿using NUnit.Framework;
+
+namespace Functional.Maybe.NTests
+{
+	class MaybeLinqTests
+	{
+		[Test]
+		public void SelectOrElseWithConversionToNullableTest()
+		{
+			Maybe<string> maybeString = Maybe<string>.Nothing;
+
+			var alternativeValue = maybeString.SelectOrElse<string, string?>(s => s, () => null);
+
+			Assert.IsNull(alternativeValue);
+		}
+
+		[Test]
+		public void SelectMaybeWithTransformationReturningNullTest()
+		{
+			var maybeString = "a".ToMaybe();
+
+			var result = maybeString.SelectMaybe<string, string, string>(
+				s => s.ToMaybe(), 
+				(s, s1) => null);
+				
+			Assert.AreEqual(Maybe<string>.Nothing, result);
+		}
+
+		[Test]
+		public void SelectManyWithTransformationReturningNullTest()
+		{
+			var maybeString = "a".ToMaybe();
+
+			var result = maybeString.SelectMany<string, string, string>(
+				s => s.ToMaybe(), 
+				(s, s1) => null);
+				
+			Assert.AreEqual(Maybe<string>.Nothing, result);
+		}
+	}
+}

--- a/Functional.Maybe.NTests/MaybeLinqTests.cs
+++ b/Functional.Maybe.NTests/MaybeLinqTests.cs
@@ -1,6 +1,6 @@
 ﻿using NUnit.Framework;
 
-namespace Functional.Maybe.NTests
+namespace Functional.Maybe.Tests
 {
 	class MaybeLinqTests
 	{

--- a/Functional.Maybe.NTests/MaybeReturnsTests.cs
+++ b/Functional.Maybe.NTests/MaybeReturnsTests.cs
@@ -1,0 +1,28 @@
+﻿using NUnit.Framework;
+
+namespace Functional.Maybe.Tests
+{
+	[TestFixture]
+	public class MaybeReturnsTests
+	{
+		[Test]
+		public void OrElseTestWhenMaybeIsNothingAndOtherIsNotNull()
+		{
+			Assert.AreEqual("a", Maybe<string>.Nothing.OrElse("a"));
+			Assert.AreEqual("a", Maybe<string>.Nothing.OrElse(() => "a"));
+		}
+
+		[Test]
+		public void OrElseTestWhenMaybeIsNothingAndOtherIsNull()
+		{
+			Assert.IsNull(Maybe<string>.Nothing.OrElse(null as string));
+			Assert.IsNull(Maybe<string>.Nothing.OrElse(() => null as string));
+		}
+
+		[Test]
+		public void OrTestWithDefaultValueWhenMaybeIsNothingAndOtherIsNull()
+		{
+			Assert.AreEqual(Maybe<string>.Nothing, Maybe<string>.Nothing.Or(null as string));
+		}
+	}
+}

--- a/Functional.Maybe.NTests/SideEffectsTest.cs
+++ b/Functional.Maybe.NTests/SideEffectsTest.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 
 namespace Functional.Maybe.Tests
 {

--- a/Functional.Maybe/Either.cs
+++ b/Functional.Maybe/Either.cs
@@ -9,11 +9,11 @@ namespace Functional.Either
     /// </summary>
     public readonly struct Either<TResult, TError>
     {
-        private readonly TResult _resultValue;
-        private readonly TError _errorValue;
+        private readonly TResult? _resultValue;
+        private readonly TError? _errorValue;
         private readonly bool _success;
 
-        private Either(TResult result, TError error, bool success)
+        private Either(TResult? result, TError? error, bool success)
         {
             _success = success;
 
@@ -60,7 +60,7 @@ namespace Functional.Either
                 throw new ArgumentNullException(nameof(errorFunc));
             }
 
-            return _success ? resultFunc(_resultValue) : errorFunc(_errorValue);
+            return _success ? resultFunc(_resultValue!) : errorFunc(_errorValue!);
         }
 
         /// <summary>
@@ -98,11 +98,11 @@ namespace Functional.Either
 
             if (_success)
             {
-                resultAction(_resultValue);
+                resultAction(_resultValue!);
             }
             else
             {
-                errorAction(_errorValue);
+                errorAction(_errorValue!);
             }
         }
 
@@ -131,9 +131,12 @@ namespace Functional.Either
             }
         }
 
-        public TResult ResultOrDefault() => Match(res => res, err => default);
-        public TError ErrorOrDefault() => Match(res => default, err => err);
+        public TResult? ResultOrDefault() => Match<TResult?>(res => res, err => default);
+        public TError? ErrorOrDefault() => Match<TError?>(res => default, err => err);
+        
+        //bug
         public TResult ResultOrDefault(TResult defaultValue) => Match(res => res, err => defaultValue);
+        //bug
         public TError ErrorOrDefault(TError defaultValue) => Match(res => defaultValue, err => err);
 
         public static implicit operator Either<TResult, TError>(TResult result) => Result(result);

--- a/Functional.Maybe/Either.cs
+++ b/Functional.Maybe/Either.cs
@@ -134,9 +134,7 @@ namespace Functional.Either
         public TResult? ResultOrDefault() => Match<TResult?>(res => res, err => default);
         public TError? ErrorOrDefault() => Match<TError?>(res => default, err => err);
         
-        //bug
         public TResult ResultOrDefault(TResult defaultValue) => Match(res => res, err => defaultValue);
-        //bug
         public TError ErrorOrDefault(TError defaultValue) => Match(res => defaultValue, err => err);
 
         public static implicit operator Either<TResult, TError>(TResult result) => Result(result);

--- a/Functional.Maybe/Functional.Maybe.csproj
+++ b/Functional.Maybe/Functional.Maybe.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard1.0</TargetFramework>
-    <LangVersion>7.2</LangVersion>
+    <LangVersion>9.0</LangVersion>
     <Version>2.0.0</Version>
     <Authors>Andrey Tsvetkov; William Cassarin</Authors>
     <PackageId>Functional.Maybe</PackageId>
@@ -29,6 +29,15 @@
     <PackageReleaseNotes>Migrated to Net Standart 1.0</PackageReleaseNotes>
     <Product>Option types for C# with LINQ support and rich fluent syntax for many popular uses</Product>
     <RepositoryUrl>https://github.com/AndreyTsvetkov/Functional.Maybe</RepositoryUrl>
+    <Nullable>enable</Nullable>
+    <WarningsAsErrors>nullable</WarningsAsErrors>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Nullable" Version="1.3.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 
 </Project>

--- a/Functional.Maybe/Maybe.cs
+++ b/Functional.Maybe/Maybe.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 
 namespace Functional.Maybe

--- a/Functional.Maybe/Maybe.cs
+++ b/Functional.Maybe/Maybe.cs
@@ -67,9 +67,9 @@ namespace Functional.Maybe
 		public bool Equals(Maybe<T> other) => 
 			EqualityComparer<T?>.Default.Equals(_value, other._value) && HasValue.Equals(other.HasValue);
 
-		public override bool Equals(object obj)
+		public override bool Equals(object? obj)
 		{
-			if (ReferenceEquals(null, obj)) return false;
+			if (obj is null) return false;
 			return obj is Maybe<T> mb && Equals(mb);
 		}
 

--- a/Functional.Maybe/Maybe.cs
+++ b/Functional.Maybe/Maybe.cs
@@ -24,7 +24,7 @@ namespace Functional.Maybe
 	/// var result = (from a in list.FirstMaybe() from b in list.LastMaybe() select a + b).OrElse(-5);
 	/// </example>
 	/// <typeparam name="T"></typeparam>
-	public readonly struct Maybe<T> : IEquatable<Maybe<T>>
+	public readonly struct Maybe<T> : IEquatable<Maybe<T>> where T : notnull
 	{
 		/// <summary>
 		/// Nothing value.
@@ -40,7 +40,7 @@ namespace Functional.Maybe
 			get
 			{
 				if (!HasValue) throw new InvalidOperationException("value is not present");
-				return _value;
+				return _value!;
 			}
 		}
 		/// <summary>
@@ -66,7 +66,7 @@ namespace Functional.Maybe
 		}
 
 		public bool Equals(Maybe<T> other) => 
-			EqualityComparer<T>.Default.Equals(_value, other._value) && HasValue.Equals(other.HasValue);
+			EqualityComparer<T?>.Default.Equals(_value, other._value) && HasValue.Equals(other.HasValue);
 
 		public override bool Equals(object obj)
 		{
@@ -78,7 +78,7 @@ namespace Functional.Maybe
 		{
 			unchecked
 			{
-				return (EqualityComparer<T>.Default.GetHashCode(_value)*397) ^ HasValue.GetHashCode();
+				return (EqualityComparer<T?>.Default.GetHashCode(_value)*397) ^ HasValue.GetHashCode();
 			}
 		}
 
@@ -88,6 +88,6 @@ namespace Functional.Maybe
 		public static bool operator !=(Maybe<T> left, Maybe<T> right) =>
 			!left.Equals(right);
 
-		private readonly T _value;
+		private readonly T? _value;
 	}
 }

--- a/Functional.Maybe/MaybeAsync.cs
+++ b/Functional.Maybe/MaybeAsync.cs
@@ -19,7 +19,8 @@ namespace Functional.Maybe
 				? (await res(@this.Value)).ToMaybe()
 				: (default);
 
-		public static async Task<T> OrElseAsync<T>(this Task<Maybe<T>> @this, Func<Task<T>> orElse) where T : notnull
+		public static async Task<TR> OrElseAsync<T, TR>(this Task<Maybe<T>> @this, Func<Task<TR>> orElse)
+      where T : notnull, TR
 		{
 			var res = await @this;
 			return res.HasValue ? res.Value : await orElse();

--- a/Functional.Maybe/MaybeAsync.cs
+++ b/Functional.Maybe/MaybeAsync.cs
@@ -20,7 +20,7 @@ namespace Functional.Maybe
 				: (default);
 
 		public static async Task<TR> OrElseAsync<T, TR>(this Task<Maybe<T>> @this, Func<Task<TR>> orElse)
-      where T : notnull, TR
+			where T : notnull, TR
 		{
 			var res = await @this;
 			return res.HasValue ? res.Value : await orElse();

--- a/Functional.Maybe/MaybeAsync.cs
+++ b/Functional.Maybe/MaybeAsync.cs
@@ -13,20 +13,25 @@ namespace Functional.Maybe
 		/// <param name="this">maybe to map</param>
 		/// <param name="res">async mapper</param>
 		/// <returns>Task of Maybe of TR</returns>
-		public static async Task<Maybe<TR>> SelectAsync<T, TR>(this Maybe<T> @this, Func<T, Task<TR>> res) => @this.HasValue
-			? (await res(@this.Value)).ToMaybe()
-			: (default);
-		public static async Task<T> OrElseAsync<T>(this Task<Maybe<T>> @this, Func<Task<T>> orElse)
+		public static async Task<Maybe<TR>> SelectAsync<T, TR>(this Maybe<T> @this, Func<T, Task<TR?>> res)
+			where T : notnull where TR : notnull =>
+			@this.HasValue
+				? (await res(@this.Value)).ToMaybe()
+				: (default);
+
+		public static async Task<T> OrElseAsync<T>(this Task<Maybe<T>> @this, Func<Task<T>> orElse) where T : notnull
 		{
 			var res = await @this;
 			return res.HasValue ? res.Value : await orElse();
 		}
-		public static async Task<T> OrElse<T>(this Task<Maybe<T>> @this, T orElse)
+		public static async Task<TResult> OrElse<T, TResult>(this Task<Maybe<T>> @this, TResult orElse) 
+			where T : notnull, TResult
 		{
 			var res = await @this;
 			return res.HasValue ? res.Value : orElse;
 		}
-		public static async Task<T> OrElse<T>(this Task<Maybe<T>> @this, Func<T> orElse)
+		public static async Task<TResult> OrElse<T, TResult>(this Task<Maybe<T>> @this, Func<TResult> orElse) 
+			where T : notnull, TResult
 		{
 			var res = await @this;
 			return res.HasValue ? res.Value : orElse();
@@ -34,12 +39,12 @@ namespace Functional.Maybe
 
 		public static async Task<TR> MatchAsync<T, TR>(this Maybe<T> @this,
 			Func<T, Task<TR>> res,
-			Func<Task<TR>> orElse) => @this.HasValue
+			Func<Task<TR>> orElse)  where T : notnull => @this.HasValue
 			? await res(@this.Value)
 			: await orElse();
 
 		public static async Task DoAsync<T>(this Maybe<T> @this,
-			Func<T, Task> res)
+			Func<T, Task> res) where T : notnull
 		{
 			if (@this.HasValue)
 			{

--- a/Functional.Maybe/MaybeBoolean.cs
+++ b/Functional.Maybe/MaybeBoolean.cs
@@ -14,7 +14,7 @@ namespace Functional.Maybe
 		/// <param name="condition"></param>
 		/// <param name="f"></param>
 		/// <returns></returns>
-		public static Maybe<T> Then<T>(this bool condition, Func<T> f) =>
+		public static Maybe<T> Then<T>(this bool condition, Func<T> f) where T : notnull =>
 			condition ? f().ToMaybe() : default;
 
 		/// <summary>
@@ -24,7 +24,7 @@ namespace Functional.Maybe
 		/// <param name="condition"></param>
 		/// <param name="t"></param>
 		/// <returns></returns>
-		public static Maybe<T> Then<T>(this bool condition, T t) =>
+		public static Maybe<T> Then<T>(this bool condition, T t) where T : notnull =>
 			condition ? t.ToMaybe() : default;
 
 		/// <summary>

--- a/Functional.Maybe/MaybeCompositions.cs
+++ b/Functional.Maybe/MaybeCompositions.cs
@@ -16,7 +16,7 @@ namespace Functional.Maybe
 		/// <param name="a"></param>
 		/// <param name="b"></param>
 		/// <returns></returns>
-		public static Maybe<T> Or<T>(this Maybe<T> a, T b) =>
+		public static Maybe<T> Or<T>(this Maybe<T> a, T? b) where T : notnull =>
 			a.IsSomething() ? a : b.ToMaybe();
 
 		/// <summary>
@@ -26,7 +26,7 @@ namespace Functional.Maybe
 		/// <param name="a"></param>
 		/// <param name="b"></param>
 		/// <returns></returns>
-		public static Maybe<T> Or<T>(this Maybe<T> a, Func<Maybe<T>> b) =>
+		public static Maybe<T> Or<T>(this Maybe<T> a, Func<Maybe<T>> b) where T : notnull =>
 			a.IsSomething() ? a : b();
 
 		/// <summary>
@@ -36,7 +36,7 @@ namespace Functional.Maybe
 		/// <param name="a"></param>
 		/// <param name="b"></param>
 		/// <returns></returns>
-		public static Maybe<T> Or<T>(this Maybe<T> a, Maybe<T> b) => a.IsSomething() ? a : b;
+		public static Maybe<T> Or<T>(this Maybe<T> a, Maybe<T> b) where T : notnull => a.IsSomething() ? a : b;
 
 		/// <summary>
 		/// Returns <paramref name="b"/> if <paramref name="a"/> has value, otherwise <see cref="Maybe&lt;T&gt;.Nothing"/>
@@ -46,7 +46,8 @@ namespace Functional.Maybe
 		/// <param name="a"></param>
 		/// <param name="b"></param>
 		/// <returns></returns>
-		public static Maybe<T2> Compose<T, T2>(this Maybe<T> a, Maybe<T2> b) =>
+		public static Maybe<T2> Compose<T, T2>(this Maybe<T> a, Maybe<T2> b) 
+      where T : notnull where T2 : notnull=>
 			a.IsNothing() ? Maybe<T2>.Nothing : b;
 
 		/// <summary>
@@ -55,7 +56,7 @@ namespace Functional.Maybe
 		/// <typeparam name="T"></typeparam>
 		/// <param name="t"></param>
 		/// <returns></returns>
-		public static Maybe<T> Collapse<T>(this Maybe<Maybe<T>> t) => t; // using implicit cast
+		public static Maybe<T> Collapse<T>(this Maybe<Maybe<T>> t) where T : notnull => t; // using implicit cast
 
 		/// <summary>
 		/// Flattens a recursive Maybe structure into IEnumerable
@@ -73,13 +74,13 @@ namespace Functional.Maybe
 		///	]
 		/// </example>
 		/// <returns></returns>
-		public static IEnumerable<T> Flatten<T>(this Maybe<T> maybe, Func<T, Maybe<T>> parentSelector) =>
+		public static IEnumerable<T> Flatten<T>(this Maybe<T> maybe, Func<T, Maybe<T>> parentSelector) where T : notnull =>
 			maybe.FlattenSelect(parentSelector, x => x);
 
-		private static IEnumerable<TFlatten> FlattenSelect<TMaybe, TFlatten>(this Maybe<TMaybe> maybe, Func<TMaybe, Maybe<TMaybe>> parentSelector, Func<TMaybe, TFlatten> flattenSelector) =>
+		private static IEnumerable<TFlatten> FlattenSelect<TMaybe, TFlatten>(this Maybe<TMaybe> maybe, Func<TMaybe, Maybe<TMaybe>> parentSelector, Func<TMaybe, TFlatten> flattenSelector) where TMaybe : notnull =>
 			maybe.Flatten(parentSelector, new List<TFlatten>(), flattenSelector);
 
-		private static IEnumerable<TFlatten> Flatten<TMaybe, TFlatten>(this Maybe<TMaybe> maybe, Func<TMaybe, Maybe<TMaybe>> parentSelector, List<TFlatten> acc, Func<TMaybe, TFlatten> flattenSelector)
+		private static IEnumerable<TFlatten> Flatten<TMaybe, TFlatten>(this Maybe<TMaybe> maybe, Func<TMaybe, Maybe<TMaybe>> parentSelector, List<TFlatten> acc, Func<TMaybe, TFlatten> flattenSelector) where TMaybe : notnull
 		{
 			while (true)
 			{

--- a/Functional.Maybe/MaybeConvertions.cs
+++ b/Functional.Maybe/MaybeConvertions.cs
@@ -28,8 +28,9 @@ namespace Functional.Maybe
 		/// <typeparam name="TR"></typeparam>
 		/// <param name="a"></param>
 		/// <returns></returns>
-		public static Maybe<TR> MaybeCast<T, TR>(this T a) where TR : T where T : notnull =>
-			MaybeFunctionalWrappers.Catcher<T, TR, InvalidCastException>(o => (TR)o)(a);
+		public static Maybe<TR> MaybeCast<T, TR>(this T a) 
+      where TR : notnull, T =>
+			MaybeFunctionalWrappers.Catcher<T?, TR, InvalidCastException>(o => (TR)o!)(a);
 
 		/// <summary>
 		/// If <paramref name="a"/>.Value is present, returns an enumerable of that single value, otherwise an empty one

--- a/Functional.Maybe/MaybeConvertions.cs
+++ b/Functional.Maybe/MaybeConvertions.cs
@@ -15,7 +15,7 @@ namespace Functional.Maybe
 		/// <typeparam name="TB"></typeparam>
 		/// <param name="a"></param>
 		/// <returns></returns>
-		public static Maybe<TB> Cast<TA, TB>(this Maybe<TA> a) where TB : class =>
+		public static Maybe<TB> Cast<TA, TB>(this Maybe<TA> a) where TB : class where TA : notnull =>
 			from m in a
 			let t = m as TB
 			where t != null
@@ -28,7 +28,7 @@ namespace Functional.Maybe
 		/// <typeparam name="TR"></typeparam>
 		/// <param name="a"></param>
 		/// <returns></returns>
-		public static Maybe<TR> MaybeCast<T, TR>(this T a) where TR : T =>
+		public static Maybe<TR> MaybeCast<T, TR>(this T a) where TR : T where T : notnull =>
 			MaybeFunctionalWrappers.Catcher<T, TR, InvalidCastException>(o => (TR)o)(a);
 
 		/// <summary>
@@ -37,7 +37,7 @@ namespace Functional.Maybe
 		/// <typeparam name="T"></typeparam>
 		/// <param name="a"></param>
 		/// <returns></returns>
-		public static IEnumerable<T> ToEnumerable<T>(this Maybe<T> a)
+		public static IEnumerable<T> ToEnumerable<T>(this Maybe<T> a) where T : notnull
 		{
 			if (a.IsSomething())
 				yield return a.Value;
@@ -67,7 +67,7 @@ namespace Functional.Maybe
 		/// <typeparam name="T"></typeparam>
 		/// <param name="a"></param>
 		/// <returns></returns>
-		public static Maybe<T> ToMaybe<T>(this T a) =>
+		public static Maybe<T> ToMaybe<T>(this T? a) where T : notnull =>
 			a == null ? default : new Maybe<T>(a);
 	}
 }

--- a/Functional.Maybe/MaybeConvertions.cs
+++ b/Functional.Maybe/MaybeConvertions.cs
@@ -29,7 +29,7 @@ namespace Functional.Maybe
 		/// <param name="a"></param>
 		/// <returns></returns>
 		public static Maybe<TR> MaybeCast<T, TR>(this T a) 
-      where TR : notnull, T =>
+			where TR : notnull, T =>
 			MaybeFunctionalWrappers.Catcher<T?, TR, InvalidCastException>(o => (TR)o!)(a);
 
 		/// <summary>

--- a/Functional.Maybe/MaybeDictionary.cs
+++ b/Functional.Maybe/MaybeDictionary.cs
@@ -18,5 +18,22 @@ namespace Functional.Maybe
 			var getter = MaybeFunctionalWrappers.Wrap<TK, T>(dictionary.TryGetValue);
 			return getter(key);
 		} //bug check this!
+
+    /// <summary>
+    /// Tries to get value from Dictionary safely
+    /// </summary>
+    /// <typeparam name="TK"></typeparam>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="dictionary"></param>
+    /// <param name="key"></param>
+    /// <returns></returns>
+    public static Maybe<T> LookupNrt<TK, T>(this IDictionary<TK, T?> dictionary, TK key) 
+      where T : notnull
+      where TK : notnull
+    {
+      var getter = MaybeFunctionalWrappers.WrapNrt<TK, T>(dictionary.TryGetValue);
+      return getter(key);
+    } //bug check this!
+
 	}
 }

--- a/Functional.Maybe/MaybeDictionary.cs
+++ b/Functional.Maybe/MaybeDictionary.cs
@@ -12,10 +12,11 @@ namespace Functional.Maybe
 		/// <param name="dictionary"></param>
 		/// <param name="key"></param>
 		/// <returns></returns>
-		public static Maybe<T> Lookup<TK, T>(this IDictionary<TK, T> dictionary, TK key)
+ 		public static Maybe<T> Lookup<TK, T>(this IDictionary<TK, T> dictionary, TK key) 
+			where T : notnull
 		{
 			var getter = MaybeFunctionalWrappers.Wrap<TK, T>(dictionary.TryGetValue);
 			return getter(key);
-		}
+		} //bug check this!
 	}
 }

--- a/Functional.Maybe/MaybeDictionary.cs
+++ b/Functional.Maybe/MaybeDictionary.cs
@@ -14,24 +14,22 @@ namespace Functional.Maybe
 		/// <returns></returns>
 		public static Maybe<T> Lookup<TK, T>(this IDictionary<TK, T> dictionary, TK key) 
 			where T : notnull
-			where TK : notnull
-		{
-			return LookupNrt(dictionary!, key);
-		}
+			where TK : notnull => Lookup<TK, T, T>(dictionary!, key);
 
 		/// <summary>
 		/// Tries to get value from Dictionary safely
 		/// </summary>
-		/// <typeparam name="TK"></typeparam>
-		/// <typeparam name="T"></typeparam>
+		/// <typeparam name="TK">dictionary key type</typeparam>
+		/// <typeparam name="TV">dictionary value type</typeparam>
+		/// <typeparam name="TR">returned maybe type</typeparam>
 		/// <param name="dictionary"></param>
 		/// <param name="key"></param>
 		/// <returns></returns>
-		public static Maybe<T> LookupNrt<TK, T>(this IDictionary<TK, T?> dictionary, TK key) 
-			where T : notnull
+		public static Maybe<TR> Lookup<TK, TV, TR>(this IDictionary<TK, TV> dictionary, TK key) 
+			where TR : notnull, TV
 			where TK : notnull
 		{
-			var getter = MaybeFunctionalWrappers.WrapNrt<TK, T>(dictionary.TryGetValue);
+			var getter = MaybeFunctionalWrappers.Wrap<TK, TV, TR>(dictionary.TryGetValue);
 			return getter(key);
 		}
 	}

--- a/Functional.Maybe/MaybeDictionary.cs
+++ b/Functional.Maybe/MaybeDictionary.cs
@@ -14,10 +14,10 @@ namespace Functional.Maybe
 		/// <returns></returns>
  		public static Maybe<T> Lookup<TK, T>(this IDictionary<TK, T> dictionary, TK key) 
 			where T : notnull
-		{
-			var getter = MaybeFunctionalWrappers.Wrap<TK, T>(dictionary.TryGetValue);
-			return getter(key);
-		} //bug check this!
+			where TK : notnull
+    {
+      return LookupNrt(dictionary!, key);
+    }
 
     /// <summary>
     /// Tries to get value from Dictionary safely
@@ -33,7 +33,6 @@ namespace Functional.Maybe
     {
       var getter = MaybeFunctionalWrappers.WrapNrt<TK, T>(dictionary.TryGetValue);
       return getter(key);
-    } //bug check this!
-
+    }
 	}
 }

--- a/Functional.Maybe/MaybeDictionary.cs
+++ b/Functional.Maybe/MaybeDictionary.cs
@@ -12,27 +12,27 @@ namespace Functional.Maybe
 		/// <param name="dictionary"></param>
 		/// <param name="key"></param>
 		/// <returns></returns>
- 		public static Maybe<T> Lookup<TK, T>(this IDictionary<TK, T> dictionary, TK key) 
+		public static Maybe<T> Lookup<TK, T>(this IDictionary<TK, T> dictionary, TK key) 
 			where T : notnull
 			where TK : notnull
-    {
-      return LookupNrt(dictionary!, key);
-    }
+		{
+			return LookupNrt(dictionary!, key);
+		}
 
-    /// <summary>
-    /// Tries to get value from Dictionary safely
-    /// </summary>
-    /// <typeparam name="TK"></typeparam>
-    /// <typeparam name="T"></typeparam>
-    /// <param name="dictionary"></param>
-    /// <param name="key"></param>
-    /// <returns></returns>
-    public static Maybe<T> LookupNrt<TK, T>(this IDictionary<TK, T?> dictionary, TK key) 
-      where T : notnull
-      where TK : notnull
-    {
-      var getter = MaybeFunctionalWrappers.WrapNrt<TK, T>(dictionary.TryGetValue);
-      return getter(key);
-    }
+		/// <summary>
+		/// Tries to get value from Dictionary safely
+		/// </summary>
+		/// <typeparam name="TK"></typeparam>
+		/// <typeparam name="T"></typeparam>
+		/// <param name="dictionary"></param>
+		/// <param name="key"></param>
+		/// <returns></returns>
+		public static Maybe<T> LookupNrt<TK, T>(this IDictionary<TK, T?> dictionary, TK key) 
+			where T : notnull
+			where TK : notnull
+		{
+			var getter = MaybeFunctionalWrappers.WrapNrt<TK, T>(dictionary.TryGetValue);
+			return getter(key);
+		}
 	}
 }

--- a/Functional.Maybe/MaybeEnumerable.cs
+++ b/Functional.Maybe/MaybeEnumerable.cs
@@ -145,23 +145,14 @@ namespace Functional.Maybe
     }
 
     /// <summary>
-    /// Returns the value of <paramref name="maybeCollection"/> if exists orlse an empty collection
+    /// Returns the value of <paramref name="maybeCollection"/> if exists or else an empty collection
     /// </summary>
     /// <typeparam name="T"></typeparam>
     /// <param name="maybeCollection"></param>
     /// <returns></returns>
     public static IEnumerable<T> FromMaybe<T>(this Maybe<IEnumerable<T>> maybeCollection) =>
-      FromMaybeNrt(maybeCollection!)!;
+      maybeCollection.HasValue ? maybeCollection.Value : Enumerable.Empty<T>();
     
-    /// <summary>
-		/// Returns the value of <paramref name="maybeCollection"/> if exists orlse an empty collection
-		/// </summary>
-		/// <typeparam name="T"></typeparam>
-		/// <param name="maybeCollection"></param>
-		/// <returns></returns>
-		public static IEnumerable<T?> FromMaybeNrt<T>(this Maybe<IEnumerable<T?>> maybeCollection) =>
-			maybeCollection.HasValue ? maybeCollection.Value : Enumerable.Empty<T?>();
-
 		/// <summary>
 		/// For each items that has value, applies <paramref name="selector"/> to it and wraps back as Maybe, for each otherwise remains Nothing
 		/// </summary>
@@ -221,7 +212,6 @@ namespace Functional.Maybe
 		public static bool AnyNothing<T>(this IEnumerable<Maybe<T>> maybes) where T : notnull =>
 			maybes.Any(m => !m.HasValue);
 
-		//bug UT and maybe an Nrt version?
 		/// <summary>
 		/// If ALL calls to <paramref name="pred"/> returned a value, filters out the <paramref name="xs"/> based on that values, otherwise returns Nothing
 		/// </summary>
@@ -243,9 +233,8 @@ namespace Functional.Maybe
 			return new Maybe<IEnumerable<T>>(l);
 		}
 
-		//bug UT and NRT version?
 		/// <summary>
-		/// Filters out <paramref name="xs"/> based on <paramref name="pred"/> resuls; Nothing considered as False
+		/// Filters out <paramref name="xs"/> based on <paramref name="pred"/> results; Nothing considered as False
 		/// </summary>
 		/// <typeparam name="T"></typeparam>
 		/// <param name="xs"></param>
@@ -258,7 +247,7 @@ namespace Functional.Maybe
 			select x;
 
 		/// <summary>
-		/// Combines all exisiting values into single IEnumerable
+		/// Combines all existing values into single IEnumerable
 		/// </summary>
 		/// <typeparam name="T"></typeparam>
 		/// <param name="this"></param>

--- a/Functional.Maybe/MaybeEnumerable.cs
+++ b/Functional.Maybe/MaybeEnumerable.cs
@@ -15,35 +15,36 @@ namespace Functional.Maybe
 		/// <typeparam name="T"></typeparam>
 		/// <param name="items"></param>
 		/// <returns></returns>
-		public static Maybe<T> FirstMaybe<T>(this IEnumerable<T> items) => 
+		public static Maybe<T> FirstMaybe<T>(this IEnumerable<T> items) where T : notnull => 
 			FirstMaybe(items, arg => true);
 
-		/// <summary>
-		/// First item matching <paramref name="predicate"/> or Nothing
-		/// </summary>
-		/// <typeparam name="T"></typeparam>
-		/// <param name="items"></param>
-		/// <param name="predicate"></param>
-		/// <returns></returns>
-		public static Maybe<T> FirstMaybe<T>(this IEnumerable<T> items, Func<T, bool> predicate)
-	    {
-	        foreach(var item in items)
-			{
-	            if (predicate(item))
-				{
-	                return item.ToMaybe();
-	            }
-	        }
-	        return Maybe<T>.Nothing;
-	    }
+    /// <summary>
+    /// First item matching <paramref name="predicate"/> or Nothing
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="items"></param>
+    /// <param name="predicate"></param>
+    /// <returns></returns>
+    public static Maybe<T> FirstMaybe<T>(this IEnumerable<T> items, Func<T, bool> predicate) where T : notnull
+    {
+      foreach (var item in items)
+      {
+        if (predicate(item))
+        {
+          return item.ToMaybe();
+        }
+      }
 
-		/// <summary>
+      return Maybe<T>.Nothing;
+    }
+
+    /// <summary>
 		/// Single item or Nothing
 		/// </summary>
 		/// <typeparam name="T"></typeparam>
 		/// <param name="items"></param>
 		/// <returns></returns>
-		public static Maybe<T> SingleMaybe<T>(this IEnumerable<T> items) => 
+		public static Maybe<T> SingleMaybe<T>(this IEnumerable<T> items) where T : notnull => 
 			SingleMaybe(items, arg => true);
 
 		/// <summary>
@@ -53,62 +54,67 @@ namespace Functional.Maybe
 		/// <param name="items"></param>
 		/// <param name="predicate"></param>
 		/// <returns></returns>
-		public static Maybe<T> SingleMaybe<T>(this IEnumerable<T> items, Func<T, bool> predicate)
+		public static Maybe<T> SingleMaybe<T>(this IEnumerable<T> items, Func<T, bool> predicate) where T : notnull
 		{
-            var result = default(T);
-            var count = 0;
-            foreach(var element in items)
+			var result = default(T);
+			var count = 0;
+			foreach (var element in items)
 			{
-                if (predicate(element))
+				if (predicate(element))
 				{
-                    result = element;
-                    count++;
+					result = element;
+					count++;
 					if (count > 1)
 					{
 						return default;
 					}
-                }
-            }
-            switch(count)
-			{
-                case 0: return default;
-                case 1: return result.ToMaybe();
-            }
-            return default;
-        }
+				}
+			}
 
-		/// <summary>
+			switch (count)
+			{
+				case 0:
+					return default;
+				case 1:
+					return result.ToMaybe();
+			}
+
+			return default;
+		}
+
+    /// <summary>
 		/// Last item or Nothing
 		/// </summary>
 		/// <typeparam name="T"></typeparam>
 		/// <param name="items"></param>
 		/// <returns></returns>
-		public static Maybe<T> LastMaybe<T>(this IEnumerable<T> items) => 
+		public static Maybe<T> LastMaybe<T>(this IEnumerable<T> items) where T : notnull => 
 			LastMaybe(items, arg => true);
 
-		/// <summary>
-		/// Last item matching <paramref name="predicate"/> or Nothing
-		/// </summary>
-		/// <typeparam name="T"></typeparam>
-		/// <param name="items"></param>
-		/// <param name="predicate"></param>
-		/// <returns></returns>
-		public static Maybe<T> LastMaybe<T>(this IEnumerable<T> items, Func<T, bool> predicate)
+    /// <summary>
+    /// Last item matching <paramref name="predicate"/> or Nothing
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="items"></param>
+    /// <param name="predicate"></param>
+    /// <returns></returns>
+    public static Maybe<T> LastMaybe<T>(this IEnumerable<T> items, Func<T, bool> predicate) where T : notnull
+    {
+	    var result = default(T);
+	    var found = false;
+	    foreach (var element in items)
 	    {
-	        var result = default(T);
-	        var found = false;
-	        foreach (var element in items)
-			{
-	            if (predicate(element))
-				{
-	                result = element;
-	                found = true;
-	            }
-	        }
-			return found ? result.ToMaybe() : default;
-		}
+		    if (predicate(element))
+		    {
+			    result = element;
+			    found = true;
+		    }
+	    }
 
-		/// <summary>
+	    return found ? result.ToMaybe() : default;
+    }
+
+    /// <summary>
 		/// Returns the value of <paramref name="maybeCollection"/> if exists orlse an empty collection
 		/// </summary>
 		/// <typeparam name="T"></typeparam>
@@ -125,7 +131,8 @@ namespace Functional.Maybe
 		/// <param name="maybes"></param>
 		/// <param name="selector"></param>
 		/// <returns></returns>
-		public static IEnumerable<Maybe<TResult>> Select<T, TResult>(this IEnumerable<Maybe<T>> maybes, Func<T, TResult> selector) =>
+		public static IEnumerable<Maybe<TResult>> Select<T, TResult>(this IEnumerable<Maybe<T>> maybes, Func<T, TResult?> selector) 
+      where T : notnull where TResult : notnull =>
 			maybes.Select(maybe => maybe.Select(selector));
 
 		/// <summary>
@@ -134,7 +141,7 @@ namespace Functional.Maybe
 		/// <typeparam name="T"></typeparam>
 		/// <param name="maybes"></param>
 		/// <returns></returns>
-		public static Maybe<IEnumerable<T>> WholeSequenceOfValues<T>(this IEnumerable<Maybe<T>> maybes)
+		public static Maybe<IEnumerable<T>> WholeSequenceOfValues<T>(this IEnumerable<Maybe<T>> maybes) where T : notnull
 		{
 			var forced = maybes.ToArray();
 			// there has got to be a better way to do this
@@ -150,7 +157,7 @@ namespace Functional.Maybe
 		/// <typeparam name="T"></typeparam>
 		/// <param name="maybes"></param>
 		/// <returns></returns>
-		public static IEnumerable<T> WhereValueExist<T>(this IEnumerable<Maybe<T>> maybes) => 
+		public static IEnumerable<T> WhereValueExist<T>(this IEnumerable<Maybe<T>> maybes) where T : notnull => 
 			SelectWhereValueExist(maybes, m => m);
 
 		/// <summary>
@@ -161,7 +168,7 @@ namespace Functional.Maybe
 		/// <param name="maybes"></param>
 		/// <param name="fn"></param>
 		/// <returns></returns>
-		public static IEnumerable<TResult> SelectWhereValueExist<T, TResult>(this IEnumerable<Maybe<T>> maybes, Func<T, TResult> fn) =>
+		public static IEnumerable<TResult> SelectWhereValueExist<T, TResult>(this IEnumerable<Maybe<T>> maybes, Func<T, TResult> fn) where T : notnull =>
 			from maybe in maybes
 			where maybe.HasValue
 			select fn(maybe.Value);
@@ -172,7 +179,7 @@ namespace Functional.Maybe
 		/// <typeparam name="T"></typeparam>
 		/// <param name="maybes"></param>
 		/// <returns></returns>
-		public static bool AnyNothing<T>(this IEnumerable<Maybe<T>> maybes) =>
+		public static bool AnyNothing<T>(this IEnumerable<Maybe<T>> maybes) where T : notnull =>
 			maybes.Any(m => !m.HasValue);
 
 		/// <summary>
@@ -216,7 +223,7 @@ namespace Functional.Maybe
 		/// <param name="this"></param>
 		/// <param name="others"></param>
 		/// <returns></returns>
-		public static IEnumerable<T> Union<T>(this Maybe<T> @this, params Maybe<T>[] others) =>
+		public static IEnumerable<T> Union<T>(this Maybe<T> @this, params Maybe<T>[] others) where T : notnull =>
 			@this.Union(others.WhereValueExist());
 
 		/// <summary>
@@ -226,7 +233,7 @@ namespace Functional.Maybe
 		/// <param name="this"></param>
 		/// <param name="others"></param>
 		/// <returns></returns>
-		public static IEnumerable<T> Union<T>(this Maybe<T> @this, IEnumerable<T> others) =>
+		public static IEnumerable<T> Union<T>(this Maybe<T> @this, IEnumerable<T> others) where T : notnull =>
 			@this.ToEnumerable().Union(others);
 
 		/// <summary>
@@ -236,7 +243,7 @@ namespace Functional.Maybe
 		/// <param name="this"></param>
 		/// <param name="others"></param>
 		/// <returns></returns>
-		public static IEnumerable<T> Union<T>(this IEnumerable<T> @these, Maybe<T> other) =>
+		public static IEnumerable<T> Union<T>(this IEnumerable<T> @these, Maybe<T> other) where T : notnull =>
 			@these.Union(other.ToEnumerable());
 	}
 }

--- a/Functional.Maybe/MaybeEnumerable.cs
+++ b/Functional.Maybe/MaybeEnumerable.cs
@@ -16,7 +16,7 @@ namespace Functional.Maybe
 		/// <param name="items"></param>
 		/// <returns></returns>
 		public static Maybe<T> FirstMaybe<T>(this IEnumerable<T?> items) where T : notnull => 
-			FirstMaybeNrt(items, arg => true);
+			FirstMaybe<T?, T>(items, arg => true);
 
 		/// <summary>
 		/// First item matching <paramref name="predicate"/> or Nothing
@@ -25,23 +25,26 @@ namespace Functional.Maybe
 		/// <param name="items"></param>
 		/// <param name="predicate"></param>
 		/// <returns></returns>
-		public static Maybe<T> FirstMaybe<T>(this IEnumerable<T> items, Func<T, bool> predicate) where T : notnull => 
-			FirstMaybeNrt(items, predicate!);
+		public static Maybe<T> FirstMaybe<T>(this IEnumerable<T> items, Func<T, bool> predicate) 
+			where T : notnull => 
+			FirstMaybe<T, T>(items, predicate);
 
 		/// <summary>
 		/// First item matching <paramref name="predicate"/> or Nothing
 		/// </summary>
 		/// <typeparam name="T"></typeparam>
+		/// <typeparam name="TE"></typeparam>
 		/// <param name="items"></param>
 		/// <param name="predicate"></param>
 		/// <returns></returns>
-		public static Maybe<T> FirstMaybeNrt<T>(this IEnumerable<T?> items, Func<T?, bool> predicate) where T : notnull
+		public static Maybe<T> FirstMaybe<TE, T>(this IEnumerable<TE> items, Func<TE, bool> predicate) 
+			where T : notnull, TE
 		{
 			foreach (var item in items)
 			{
 				if (predicate(item))
 				{
-					return item.ToMaybe();
+					return item.MaybeCast<TE, T>();
 				}
 			}
 
@@ -55,7 +58,7 @@ namespace Functional.Maybe
 		/// <param name="items"></param>
 		/// <returns></returns>
 		public static Maybe<T> SingleMaybe<T>(this IEnumerable<T?> items) where T : notnull => 
-			SingleMaybeNrt(items, arg => true);
+			SingleMaybe<T?, T>(items, arg => true);
 
 		/// <summary>
 		/// Single item matching <paramref name="predicate"/> or Nothing
@@ -65,18 +68,20 @@ namespace Functional.Maybe
 		/// <param name="predicate"></param>
 		/// <returns></returns>
 		public static Maybe<T> SingleMaybe<T>(this IEnumerable<T> items, Func<T, bool> predicate) where T : notnull
-			=> SingleMaybeNrt(items, predicate!);
+			=> SingleMaybe<T, T>(items, predicate);
 
 		/// <summary>
 		/// Single item matching <paramref name="predicate"/> or Nothing
 		/// </summary>
 		/// <typeparam name="T"></typeparam>
+		/// <typeparam name="TE"></typeparam>
 		/// <param name="items"></param>
 		/// <param name="predicate"></param>
 		/// <returns></returns>
-		public static Maybe<T> SingleMaybeNrt<T>(this IEnumerable<T?> items, Func<T?, bool> predicate) where T : notnull
+		public static Maybe<T> SingleMaybe<TE, T>(this IEnumerable<TE> items, Func<TE, bool> predicate) 
+			where T : notnull, TE
 		{
-			var result = default(T);
+			var result = default(TE);
 			var count = 0;
 			foreach (var element in items)
 			{
@@ -96,7 +101,7 @@ namespace Functional.Maybe
 				case 0:
 					return default;
 				case 1:
-					return result.ToMaybe();
+					return result.MaybeCast<TE?, T>();
 			}
 
 			return default;
@@ -109,7 +114,7 @@ namespace Functional.Maybe
 		/// <param name="items"></param>
 		/// <returns></returns>
 		public static Maybe<T> LastMaybe<T>(this IEnumerable<T?> items) where T : notnull => 
-			LastMaybeNrt(items, arg => true);
+			LastMaybe<T?, T>(items, arg => true);
 
 		/// <summary>
 		/// Last item matching <paramref name="predicate"/> or Nothing
@@ -119,18 +124,20 @@ namespace Functional.Maybe
 		/// <param name="predicate"></param>
 		/// <returns></returns>
 		public static Maybe<T> LastMaybe<T>(this IEnumerable<T> items, Func<T, bool> predicate) where T : notnull
-			=> LastMaybeNrt(items, predicate!);
+			=> LastMaybe<T, T>(items, predicate);
 
 		/// <summary>
 		/// Last item matching <paramref name="predicate"/> or Nothing
 		/// </summary>
 		/// <typeparam name="T"></typeparam>
+		/// <typeparam name="TE"></typeparam>
 		/// <param name="items"></param>
 		/// <param name="predicate"></param>
 		/// <returns></returns>
-		public static Maybe<T> LastMaybeNrt<T>(this IEnumerable<T?> items, Func<T?, bool> predicate) where T : notnull
+		public static Maybe<T> LastMaybe<TE, T>(this IEnumerable<TE> items, Func<TE, bool> predicate)
+			where T : notnull, TE
 		{
-			var result = default(T);
+			var result = default(TE);
 			var found = false;
 			foreach (var element in items)
 			{
@@ -141,7 +148,7 @@ namespace Functional.Maybe
 				}
 			}
 
-			return found ? result.ToMaybe() : default;
+			return found ? result.MaybeCast<TE?, T>() : default;
 		}
 
 		/// <summary>

--- a/Functional.Maybe/MaybeEnumerable.cs
+++ b/Functional.Maybe/MaybeEnumerable.cs
@@ -18,37 +18,37 @@ namespace Functional.Maybe
 		public static Maybe<T> FirstMaybe<T>(this IEnumerable<T?> items) where T : notnull => 
 			FirstMaybeNrt(items, arg => true);
 
-    /// <summary>
-    /// First item matching <paramref name="predicate"/> or Nothing
-    /// </summary>
-    /// <typeparam name="T"></typeparam>
-    /// <param name="items"></param>
-    /// <param name="predicate"></param>
-    /// <returns></returns>
-    public static Maybe<T> FirstMaybe<T>(this IEnumerable<T> items, Func<T, bool> predicate) where T : notnull => 
-      FirstMaybeNrt(items, predicate!);
+		/// <summary>
+		/// First item matching <paramref name="predicate"/> or Nothing
+		/// </summary>
+		/// <typeparam name="T"></typeparam>
+		/// <param name="items"></param>
+		/// <param name="predicate"></param>
+		/// <returns></returns>
+		public static Maybe<T> FirstMaybe<T>(this IEnumerable<T> items, Func<T, bool> predicate) where T : notnull => 
+			FirstMaybeNrt(items, predicate!);
 
-    /// <summary>
-    /// First item matching <paramref name="predicate"/> or Nothing
-    /// </summary>
-    /// <typeparam name="T"></typeparam>
-    /// <param name="items"></param>
-    /// <param name="predicate"></param>
-    /// <returns></returns>
-    public static Maybe<T> FirstMaybeNrt<T>(this IEnumerable<T?> items, Func<T?, bool> predicate) where T : notnull
-    {
-      foreach (var item in items)
-      {
-        if (predicate(item))
-        {
-          return item.ToMaybe();
-        }
-      }
+		/// <summary>
+		/// First item matching <paramref name="predicate"/> or Nothing
+		/// </summary>
+		/// <typeparam name="T"></typeparam>
+		/// <param name="items"></param>
+		/// <param name="predicate"></param>
+		/// <returns></returns>
+		public static Maybe<T> FirstMaybeNrt<T>(this IEnumerable<T?> items, Func<T?, bool> predicate) where T : notnull
+		{
+			foreach (var item in items)
+			{
+				if (predicate(item))
+				{
+					return item.ToMaybe();
+				}
+			}
 
-      return Maybe<T>.Nothing;
-    }
+			return Maybe<T>.Nothing;
+		}
 
-    /// <summary>
+		/// <summary>
 		/// Single item or Nothing
 		/// </summary>
 		/// <typeparam name="T"></typeparam>
@@ -57,15 +57,15 @@ namespace Functional.Maybe
 		public static Maybe<T> SingleMaybe<T>(this IEnumerable<T?> items) where T : notnull => 
 			SingleMaybeNrt(items, arg => true);
 
-    /// <summary>
-    /// Single item matching <paramref name="predicate"/> or Nothing
-    /// </summary>
-    /// <typeparam name="T"></typeparam>
-    /// <param name="items"></param>
-    /// <param name="predicate"></param>
-    /// <returns></returns>
-    public static Maybe<T> SingleMaybe<T>(this IEnumerable<T> items, Func<T, bool> predicate) where T : notnull
-      => SingleMaybeNrt(items, predicate!);
+		/// <summary>
+		/// Single item matching <paramref name="predicate"/> or Nothing
+		/// </summary>
+		/// <typeparam name="T"></typeparam>
+		/// <param name="items"></param>
+		/// <param name="predicate"></param>
+		/// <returns></returns>
+		public static Maybe<T> SingleMaybe<T>(this IEnumerable<T> items, Func<T, bool> predicate) where T : notnull
+			=> SingleMaybeNrt(items, predicate!);
 
 		/// <summary>
 		/// Single item matching <paramref name="predicate"/> or Nothing
@@ -102,56 +102,56 @@ namespace Functional.Maybe
 			return default;
 		}
 
-    /// <summary>
+		/// <summary>
 		/// Last item or Nothing
 		/// </summary>
 		/// <typeparam name="T"></typeparam>
 		/// <param name="items"></param>
 		/// <returns></returns>
-	  public static Maybe<T> LastMaybe<T>(this IEnumerable<T?> items) where T : notnull => 
-  		LastMaybeNrt(items, arg => true);
+		public static Maybe<T> LastMaybe<T>(this IEnumerable<T?> items) where T : notnull => 
+			LastMaybeNrt(items, arg => true);
 
-    /// <summary>
-    /// Last item matching <paramref name="predicate"/> or Nothing
-    /// </summary>
-    /// <typeparam name="T"></typeparam>
-    /// <param name="items"></param>
-    /// <param name="predicate"></param>
-    /// <returns></returns>
-    public static Maybe<T> LastMaybe<T>(this IEnumerable<T> items, Func<T, bool> predicate) where T : notnull
-      => LastMaybeNrt(items, predicate!);
+		/// <summary>
+		/// Last item matching <paramref name="predicate"/> or Nothing
+		/// </summary>
+		/// <typeparam name="T"></typeparam>
+		/// <param name="items"></param>
+		/// <param name="predicate"></param>
+		/// <returns></returns>
+		public static Maybe<T> LastMaybe<T>(this IEnumerable<T> items, Func<T, bool> predicate) where T : notnull
+			=> LastMaybeNrt(items, predicate!);
 
-    /// <summary>
-    /// Last item matching <paramref name="predicate"/> or Nothing
-    /// </summary>
-    /// <typeparam name="T"></typeparam>
-    /// <param name="items"></param>
-    /// <param name="predicate"></param>
-    /// <returns></returns>
-    public static Maybe<T> LastMaybeNrt<T>(this IEnumerable<T?> items, Func<T?, bool> predicate) where T : notnull
-    {
-	    var result = default(T);
-	    var found = false;
-	    foreach (var element in items)
-	    {
-		    if (predicate(element))
-		    {
-			    result = element;
-			    found = true;
-		    }
-	    }
+		/// <summary>
+		/// Last item matching <paramref name="predicate"/> or Nothing
+		/// </summary>
+		/// <typeparam name="T"></typeparam>
+		/// <param name="items"></param>
+		/// <param name="predicate"></param>
+		/// <returns></returns>
+		public static Maybe<T> LastMaybeNrt<T>(this IEnumerable<T?> items, Func<T?, bool> predicate) where T : notnull
+		{
+			var result = default(T);
+			var found = false;
+			foreach (var element in items)
+			{
+				if (predicate(element))
+				{
+					result = element;
+					found = true;
+				}
+			}
 
-	    return found ? result.ToMaybe() : default;
-    }
+			return found ? result.ToMaybe() : default;
+		}
 
-    /// <summary>
-    /// Returns the value of <paramref name="maybeCollection"/> if exists or else an empty collection
-    /// </summary>
-    /// <typeparam name="T"></typeparam>
-    /// <param name="maybeCollection"></param>
-    /// <returns></returns>
-    public static IEnumerable<T> FromMaybe<T>(this Maybe<IEnumerable<T>> maybeCollection) =>
-      maybeCollection.HasValue ? maybeCollection.Value : Enumerable.Empty<T>();
+		/// <summary>
+		/// Returns the value of <paramref name="maybeCollection"/> if exists or else an empty collection
+		/// </summary>
+		/// <typeparam name="T"></typeparam>
+		/// <param name="maybeCollection"></param>
+		/// <returns></returns>
+		public static IEnumerable<T> FromMaybe<T>(this Maybe<IEnumerable<T>> maybeCollection) =>
+			maybeCollection.HasValue ? maybeCollection.Value : Enumerable.Empty<T>();
     
 		/// <summary>
 		/// For each items that has value, applies <paramref name="selector"/> to it and wraps back as Maybe, for each otherwise remains Nothing
@@ -162,7 +162,7 @@ namespace Functional.Maybe
 		/// <param name="selector"></param>
 		/// <returns></returns>
 		public static IEnumerable<Maybe<TResult>> Select<T, TResult>(this IEnumerable<Maybe<T>> maybes, Func<T, TResult?> selector) 
-      where T : notnull where TResult : notnull =>
+			where T : notnull where TResult : notnull =>
 			maybes.Select(maybe => maybe.Select(selector));
 
 		/// <summary>

--- a/Functional.Maybe/MaybeEnumerable.cs
+++ b/Functional.Maybe/MaybeEnumerable.cs
@@ -15,17 +15,7 @@ namespace Functional.Maybe
 		/// <typeparam name="T"></typeparam>
 		/// <param name="items"></param>
 		/// <returns></returns>
-		public static Maybe<T> FirstMaybe<T>(this IEnumerable<T> items) where T : notnull => 
-			FirstMaybeNrt(items);
-
-		//bug
-		/// <summary>
-		/// First item or Nothing
-		/// </summary>
-		/// <typeparam name="T"></typeparam>
-		/// <param name="items"></param>
-		/// <returns></returns>
-		public static Maybe<T> FirstMaybeNrt<T>(this IEnumerable<T?> items) where T : notnull => 
+		public static Maybe<T> FirstMaybe<T>(this IEnumerable<T?> items) where T : notnull => 
 			FirstMaybeNrt(items, arg => true);
 
     /// <summary>
@@ -35,12 +25,9 @@ namespace Functional.Maybe
     /// <param name="items"></param>
     /// <param name="predicate"></param>
     /// <returns></returns>
-    public static Maybe<T> FirstMaybe<T>(this IEnumerable<T> items, Func<T, bool> predicate) where T : notnull
-    {
-      return FirstMaybeNrt(items, predicate!);
-    }
+    public static Maybe<T> FirstMaybe<T>(this IEnumerable<T> items, Func<T, bool> predicate) where T : notnull => 
+      FirstMaybeNrt(items, predicate!);
 
-		//bug start here
     /// <summary>
     /// First item matching <paramref name="predicate"/> or Nothing
     /// </summary>
@@ -67,17 +54,8 @@ namespace Functional.Maybe
 		/// <typeparam name="T"></typeparam>
 		/// <param name="items"></param>
 		/// <returns></returns>
-		public static Maybe<T> SingleMaybeNrt<T>(this IEnumerable<T?> items) where T : notnull => 
+		public static Maybe<T> SingleMaybe<T>(this IEnumerable<T?> items) where T : notnull => 
 			SingleMaybeNrt(items, arg => true);
-
-    /// <summary>
-		/// Single item or Nothing
-		/// </summary>
-		/// <typeparam name="T"></typeparam>
-		/// <param name="items"></param>
-		/// <returns></returns>
-		public static Maybe<T> SingleMaybe<T>(this IEnumerable<T> items) where T : notnull => 
-			SingleMaybeNrt(items); //bug pass without suppression?
 
     /// <summary>
     /// Single item matching <paramref name="predicate"/> or Nothing
@@ -130,17 +108,8 @@ namespace Functional.Maybe
 		/// <typeparam name="T"></typeparam>
 		/// <param name="items"></param>
 		/// <returns></returns>
-		public static Maybe<T> LastMaybe<T>(this IEnumerable<T> items) where T : notnull => 
-			LastMaybeNrt(items);
-
-    /// <summary>
-		/// Last item or Nothing
-		/// </summary>
-		/// <typeparam name="T"></typeparam>
-		/// <param name="items"></param>
-		/// <returns></returns>
-		public static Maybe<T> LastMaybeNrt<T>(this IEnumerable<T?> items) where T : notnull => 
-			LastMaybeNrt(items, arg => true);
+	  public static Maybe<T> LastMaybe<T>(this IEnumerable<T?> items) where T : notnull => 
+  		LastMaybeNrt(items, arg => true);
 
     /// <summary>
     /// Last item matching <paramref name="predicate"/> or Nothing

--- a/Functional.Maybe/MaybeEnumerable.cs
+++ b/Functional.Maybe/MaybeEnumerable.cs
@@ -16,7 +16,17 @@ namespace Functional.Maybe
 		/// <param name="items"></param>
 		/// <returns></returns>
 		public static Maybe<T> FirstMaybe<T>(this IEnumerable<T> items) where T : notnull => 
-			FirstMaybe(items, arg => true);
+			FirstMaybeNrt(items);
+
+		//bug
+		/// <summary>
+		/// First item or Nothing
+		/// </summary>
+		/// <typeparam name="T"></typeparam>
+		/// <param name="items"></param>
+		/// <returns></returns>
+		public static Maybe<T> FirstMaybeNrt<T>(this IEnumerable<T?> items) where T : notnull => 
+			FirstMaybeNrt(items, arg => true);
 
     /// <summary>
     /// First item matching <paramref name="predicate"/> or Nothing
@@ -26,6 +36,19 @@ namespace Functional.Maybe
     /// <param name="predicate"></param>
     /// <returns></returns>
     public static Maybe<T> FirstMaybe<T>(this IEnumerable<T> items, Func<T, bool> predicate) where T : notnull
+    {
+      return FirstMaybeNrt(items, predicate!);
+    }
+
+		//bug start here
+    /// <summary>
+    /// First item matching <paramref name="predicate"/> or Nothing
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="items"></param>
+    /// <param name="predicate"></param>
+    /// <returns></returns>
+    public static Maybe<T> FirstMaybeNrt<T>(this IEnumerable<T?> items, Func<T?, bool> predicate) where T : notnull
     {
       foreach (var item in items)
       {
@@ -44,8 +67,27 @@ namespace Functional.Maybe
 		/// <typeparam name="T"></typeparam>
 		/// <param name="items"></param>
 		/// <returns></returns>
+		public static Maybe<T> SingleMaybeNrt<T>(this IEnumerable<T?> items) where T : notnull => 
+			SingleMaybeNrt(items, arg => true);
+
+    /// <summary>
+		/// Single item or Nothing
+		/// </summary>
+		/// <typeparam name="T"></typeparam>
+		/// <param name="items"></param>
+		/// <returns></returns>
 		public static Maybe<T> SingleMaybe<T>(this IEnumerable<T> items) where T : notnull => 
-			SingleMaybe(items, arg => true);
+			SingleMaybeNrt(items); //bug pass without suppression?
+
+    /// <summary>
+    /// Single item matching <paramref name="predicate"/> or Nothing
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="items"></param>
+    /// <param name="predicate"></param>
+    /// <returns></returns>
+    public static Maybe<T> SingleMaybe<T>(this IEnumerable<T> items, Func<T, bool> predicate) where T : notnull
+      => SingleMaybeNrt(items, predicate!);
 
 		/// <summary>
 		/// Single item matching <paramref name="predicate"/> or Nothing
@@ -54,7 +96,7 @@ namespace Functional.Maybe
 		/// <param name="items"></param>
 		/// <param name="predicate"></param>
 		/// <returns></returns>
-		public static Maybe<T> SingleMaybe<T>(this IEnumerable<T> items, Func<T, bool> predicate) where T : notnull
+		public static Maybe<T> SingleMaybeNrt<T>(this IEnumerable<T?> items, Func<T?, bool> predicate) where T : notnull
 		{
 			var result = default(T);
 			var count = 0;
@@ -89,7 +131,16 @@ namespace Functional.Maybe
 		/// <param name="items"></param>
 		/// <returns></returns>
 		public static Maybe<T> LastMaybe<T>(this IEnumerable<T> items) where T : notnull => 
-			LastMaybe(items, arg => true);
+			LastMaybeNrt(items);
+
+    /// <summary>
+		/// Last item or Nothing
+		/// </summary>
+		/// <typeparam name="T"></typeparam>
+		/// <param name="items"></param>
+		/// <returns></returns>
+		public static Maybe<T> LastMaybeNrt<T>(this IEnumerable<T?> items) where T : notnull => 
+			LastMaybeNrt(items, arg => true);
 
     /// <summary>
     /// Last item matching <paramref name="predicate"/> or Nothing
@@ -99,6 +150,16 @@ namespace Functional.Maybe
     /// <param name="predicate"></param>
     /// <returns></returns>
     public static Maybe<T> LastMaybe<T>(this IEnumerable<T> items, Func<T, bool> predicate) where T : notnull
+      => LastMaybeNrt(items, predicate!);
+
+    /// <summary>
+    /// Last item matching <paramref name="predicate"/> or Nothing
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="items"></param>
+    /// <param name="predicate"></param>
+    /// <returns></returns>
+    public static Maybe<T> LastMaybeNrt<T>(this IEnumerable<T?> items, Func<T?, bool> predicate) where T : notnull
     {
 	    var result = default(T);
 	    var found = false;
@@ -115,13 +176,22 @@ namespace Functional.Maybe
     }
 
     /// <summary>
+    /// Returns the value of <paramref name="maybeCollection"/> if exists orlse an empty collection
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="maybeCollection"></param>
+    /// <returns></returns>
+    public static IEnumerable<T> FromMaybe<T>(this Maybe<IEnumerable<T>> maybeCollection) =>
+      FromMaybeNrt(maybeCollection!)!;
+    
+    /// <summary>
 		/// Returns the value of <paramref name="maybeCollection"/> if exists orlse an empty collection
 		/// </summary>
 		/// <typeparam name="T"></typeparam>
 		/// <param name="maybeCollection"></param>
 		/// <returns></returns>
-		public static IEnumerable<T> FromMaybe<T>(this Maybe<IEnumerable<T>> maybeCollection) =>
-			maybeCollection.HasValue ? maybeCollection.Value : Enumerable.Empty<T>();
+		public static IEnumerable<T?> FromMaybeNrt<T>(this Maybe<IEnumerable<T?>> maybeCollection) =>
+			maybeCollection.HasValue ? maybeCollection.Value : Enumerable.Empty<T?>();
 
 		/// <summary>
 		/// For each items that has value, applies <paramref name="selector"/> to it and wraps back as Maybe, for each otherwise remains Nothing
@@ -182,6 +252,7 @@ namespace Functional.Maybe
 		public static bool AnyNothing<T>(this IEnumerable<Maybe<T>> maybes) where T : notnull =>
 			maybes.Any(m => !m.HasValue);
 
+		//bug UT and maybe an Nrt version?
 		/// <summary>
 		/// If ALL calls to <paramref name="pred"/> returned a value, filters out the <paramref name="xs"/> based on that values, otherwise returns Nothing
 		/// </summary>
@@ -203,6 +274,7 @@ namespace Functional.Maybe
 			return new Maybe<IEnumerable<T>>(l);
 		}
 
+		//bug UT and NRT version?
 		/// <summary>
 		/// Filters out <paramref name="xs"/> based on <paramref name="pred"/> resuls; Nothing considered as False
 		/// </summary>

--- a/Functional.Maybe/MaybeFunctionalWrappers.cs
+++ b/Functional.Maybe/MaybeFunctionalWrappers.cs
@@ -27,7 +27,6 @@ namespace Functional.Maybe
     public static Func<TK, Maybe<TR>> Wrap<TK, TR>(TryGet<TK, TR> tryer)  
 			where TR : notnull => WrapNrt(tryer!);
 
-    //bug comment
     /// <summary>
     /// Converts a standard tryer function (like int.TryParse, Dictionary.TryGetValue etc.) to a function, returning Maybe
     /// </summary>
@@ -39,7 +38,6 @@ namespace Functional.Maybe
       where TR : notnull => (TK arg) => 
       tryer(arg, out var result) ? result.ToMaybe() : Maybe<TR>.Nothing;
 
-    //bug check it out
     /// <summary>
     /// Returns a function which calls <paramref name="f"/>, wrapped inside a try-catch clause with <typeparamref name="TEx"/> catched. 
     /// That new function returns Nothing in the case of the <typeparamref name="TEx"/> thrown inside <paramref name="f"/>, otherwise it returns the f-result as Maybe
@@ -49,11 +47,10 @@ namespace Functional.Maybe
     /// <typeparam name="TEx"></typeparam>
     /// <param name="f"></param>
     /// <returns></returns>
-    //bug is this delegation even needed?
     public static Func<TA, Maybe<TR>> Catcher<TA, TR, TEx>(Func<TA, TR> f)
-      where TEx : Exception where TR : notnull => CatcherNrt<TA, TR, TEx>(f);
+      where TEx : Exception where TR : notnull => 
+      CatcherNrt<TA, TR, TEx>(f);
 
-    //bug check it out
     /// <summary>
     /// Returns a function which calls <paramref name="f"/>, wrapped inside a try-catch clause with <typeparamref name="TEx"/> catched. 
     /// That new function returns Nothing in the case of the <typeparamref name="TEx"/> thrown inside <paramref name="f"/>, otherwise it returns the f-result as Maybe

--- a/Functional.Maybe/MaybeFunctionalWrappers.cs
+++ b/Functional.Maybe/MaybeFunctionalWrappers.cs
@@ -7,51 +7,74 @@ namespace Functional.Maybe
 	/// </summary>
 	public static class MaybeFunctionalWrappers
 	{
-		/// <summary>
-		/// Delegate matching usual form of the TryParse methods, such as int.TryParse
-		/// </summary>
-		/// <typeparam name="TR"></typeparam>
-		/// <typeparam name="T"></typeparam>
-		/// <param name="key"></param>
-		/// <param name="val"></param>
-		/// <returns></returns>
-		public delegate bool TryGet<in T, TR>(T key, out TR val);
+    /// <summary>
+    /// Delegate matching usual form of the TryParse methods, such as int.TryParse
+    /// </summary>
+    /// <typeparam name="TR"></typeparam>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="key"></param>
+    /// <param name="val"></param>
+    /// <returns></returns>
+    public delegate bool TryGet<in T, TR>(T key, out TR val);
 
-		/// <summary>
-		/// Converts a stardard tryer function (like int.TryParse, Dictionary.TryGetValue etc.) to a function, returning Maybe
-		/// </summary>
-		/// <typeparam name="TR"></typeparam>
-		/// <typeparam name="TK"></typeparam>
-		/// <param name="tryer"></param>
-		/// <returns></returns>
-		public static Func<TK, Maybe<TR>> Wrap<TK, TR>(TryGet<TK, TR> tryer)  
-			where TR : notnull => (TK arg) =>
-		{
-			TR result;
-			return tryer(arg, out result)
-				? result.ToMaybe()
-				: Maybe<TR>.Nothing;
-		};
+    /// <summary>
+    /// Converts a stardard tryer function (like int.TryParse, Dictionary.TryGetValue etc.) to a function, returning Maybe
+    /// </summary>
+    /// <typeparam name="TR"></typeparam>
+    /// <typeparam name="TK"></typeparam>
+    /// <param name="tryer"></param>
+    /// <returns></returns>
+    public static Func<TK, Maybe<TR>> Wrap<TK, TR>(TryGet<TK, TR> tryer)  
+			where TR : notnull => WrapNrt(tryer!);
 
-		/// <summary>
-		/// Returns a function which calls <paramref name="f"/>, wrapped inside a try-catch clause with <typeparamref name="TEx"/> catched. 
-		/// That new function returns Nothing in the case of the <typeparamref name="TEx"/> thrown inside <paramref name="f"/>, otherwise it returns the f-result as Maybe
-		/// </summary>
-		/// <typeparam name="TA"></typeparam>
-		/// <typeparam name="TR"></typeparam>
-		/// <typeparam name="TEx"></typeparam>
-		/// <param name="f"></param>
-		/// <returns></returns>
-		public static Func<TA, Maybe<TR>> Catcher<TA, TR, TEx>(Func<TA, TR> f) where TEx : Exception where TR : notnull => (TA arg) =>
-		{
-			try
-			{
-				return f(arg).ToMaybe();
-			}
-			catch (TEx)
-			{
-				return default;
-			}
-		};
-	}
+    //bug comment
+    /// <summary>
+    /// Converts a stardard tryer function (like int.TryParse, Dictionary.TryGetValue etc.) to a function, returning Maybe
+    /// </summary>
+    /// <typeparam name="TR"></typeparam>
+    /// <typeparam name="TK"></typeparam>
+    /// <param name="tryer"></param>
+    /// <returns></returns>
+    public static Func<TK, Maybe<TR>> WrapNrt<TK, TR>(MaybeFunctionalWrappers.TryGet<TK, TR?> tryer)  
+      where TR : notnull => (TK arg) => 
+      tryer(arg, out var result) ? result.ToMaybe() : Maybe<TR>.Nothing;
+
+    //bug check it out
+    /// <summary>
+    /// Returns a function which calls <paramref name="f"/>, wrapped inside a try-catch clause with <typeparamref name="TEx"/> catched. 
+    /// That new function returns Nothing in the case of the <typeparamref name="TEx"/> thrown inside <paramref name="f"/>, otherwise it returns the f-result as Maybe
+    /// </summary>
+    /// <typeparam name="TA"></typeparam>
+    /// <typeparam name="TR"></typeparam>
+    /// <typeparam name="TEx"></typeparam>
+    /// <param name="f"></param>
+    /// <returns></returns>
+    //bug is this delegation even needed?
+    public static Func<TA, Maybe<TR>> Catcher<TA, TR, TEx>(Func<TA, TR> f)
+      where TEx : Exception where TR : notnull => CatcherNrt<TA, TR, TEx>(f);
+
+    //bug check it out
+    /// <summary>
+    /// Returns a function which calls <paramref name="f"/>, wrapped inside a try-catch clause with <typeparamref name="TEx"/> catched. 
+    /// That new function returns Nothing in the case of the <typeparamref name="TEx"/> thrown inside <paramref name="f"/>, otherwise it returns the f-result as Maybe
+    /// </summary>
+    /// <typeparam name="TA"></typeparam>
+    /// <typeparam name="TR"></typeparam>
+    /// <typeparam name="TEx"></typeparam>
+    /// <param name="f"></param>
+    /// <returns></returns>
+    public static Func<TA, Maybe<TR>> CatcherNrt<TA, TR, TEx>(Func<TA, TR?> f) 
+      where TEx : Exception where TR : notnull => (TA arg) =>
+    {
+      try
+      {
+        return f(arg).ToMaybe();
+      }
+      catch (TEx)
+      {
+        return default;
+      }
+    };
+
+  }
 }

--- a/Functional.Maybe/MaybeFunctionalWrappers.cs
+++ b/Functional.Maybe/MaybeFunctionalWrappers.cs
@@ -21,10 +21,11 @@ namespace Functional.Maybe
 		/// Converts a stardard tryer function (like int.TryParse, Dictionary.TryGetValue etc.) to a function, returning Maybe
 		/// </summary>
 		/// <typeparam name="TR"></typeparam>
-		/// <typeparam name="T"></typeparam>
+		/// <typeparam name="TK"></typeparam>
 		/// <param name="tryer"></param>
 		/// <returns></returns>
-		public static Func<T, Maybe<TR>> Wrap<T, TR>(TryGet<T, TR> tryer) => (T arg) =>
+		public static Func<TK, Maybe<TR>> Wrap<TK, TR>(TryGet<TK, TR> tryer)  
+			where TR : notnull => (TK arg) =>
 		{
 			TR result;
 			return tryer(arg, out result)
@@ -41,7 +42,7 @@ namespace Functional.Maybe
 		/// <typeparam name="TEx"></typeparam>
 		/// <param name="f"></param>
 		/// <returns></returns>
-		public static Func<TA, Maybe<TR>> Catcher<TA, TR, TEx>(Func<TA, TR> f) where TEx : Exception => (TA arg) =>
+		public static Func<TA, Maybe<TR>> Catcher<TA, TR, TEx>(Func<TA, TR> f) where TEx : Exception where TR : notnull => (TA arg) =>
 		{
 			try
 			{

--- a/Functional.Maybe/MaybeFunctionalWrappers.cs
+++ b/Functional.Maybe/MaybeFunctionalWrappers.cs
@@ -18,7 +18,7 @@ namespace Functional.Maybe
     public delegate bool TryGet<in T, TR>(T key, out TR val);
 
     /// <summary>
-    /// Converts a stardard tryer function (like int.TryParse, Dictionary.TryGetValue etc.) to a function, returning Maybe
+    /// Converts a standard tryer function (like int.TryParse, Dictionary.TryGetValue etc.) to a function, returning Maybe
     /// </summary>
     /// <typeparam name="TR"></typeparam>
     /// <typeparam name="TK"></typeparam>
@@ -29,13 +29,13 @@ namespace Functional.Maybe
 
     //bug comment
     /// <summary>
-    /// Converts a stardard tryer function (like int.TryParse, Dictionary.TryGetValue etc.) to a function, returning Maybe
+    /// Converts a standard tryer function (like int.TryParse, Dictionary.TryGetValue etc.) to a function, returning Maybe
     /// </summary>
     /// <typeparam name="TR"></typeparam>
     /// <typeparam name="TK"></typeparam>
     /// <param name="tryer"></param>
     /// <returns></returns>
-    public static Func<TK, Maybe<TR>> WrapNrt<TK, TR>(MaybeFunctionalWrappers.TryGet<TK, TR?> tryer)  
+    public static Func<TK, Maybe<TR>> WrapNrt<TK, TR>(TryGet<TK, TR?> tryer)  
       where TR : notnull => (TK arg) => 
       tryer(arg, out var result) ? result.ToMaybe() : Maybe<TR>.Nothing;
 

--- a/Functional.Maybe/MaybeFunctionalWrappers.cs
+++ b/Functional.Maybe/MaybeFunctionalWrappers.cs
@@ -7,71 +7,71 @@ namespace Functional.Maybe
 	/// </summary>
 	public static class MaybeFunctionalWrappers
 	{
-    /// <summary>
-    /// Delegate matching usual form of the TryParse methods, such as int.TryParse
-    /// </summary>
-    /// <typeparam name="TR"></typeparam>
-    /// <typeparam name="T"></typeparam>
-    /// <param name="key"></param>
-    /// <param name="val"></param>
-    /// <returns></returns>
-    public delegate bool TryGet<in T, TR>(T key, out TR val);
+		/// <summary>
+		/// Delegate matching usual form of the TryParse methods, such as int.TryParse
+		/// </summary>
+		/// <typeparam name="TR"></typeparam>
+		/// <typeparam name="T"></typeparam>
+		/// <param name="key"></param>
+		/// <param name="val"></param>
+		/// <returns></returns>
+		public delegate bool TryGet<in T, TR>(T key, out TR val);
 
-    /// <summary>
-    /// Converts a standard tryer function (like int.TryParse, Dictionary.TryGetValue etc.) to a function, returning Maybe
-    /// </summary>
-    /// <typeparam name="TR"></typeparam>
-    /// <typeparam name="TK"></typeparam>
-    /// <param name="tryer"></param>
-    /// <returns></returns>
-    public static Func<TK, Maybe<TR>> Wrap<TK, TR>(TryGet<TK, TR> tryer)  
+		/// <summary>
+		/// Converts a standard tryer function (like int.TryParse, Dictionary.TryGetValue etc.) to a function, returning Maybe
+		/// </summary>
+		/// <typeparam name="TR"></typeparam>
+		/// <typeparam name="TK"></typeparam>
+		/// <param name="tryer"></param>
+		/// <returns></returns>
+		public static Func<TK, Maybe<TR>> Wrap<TK, TR>(TryGet<TK, TR> tryer)  
 			where TR : notnull => WrapNrt(tryer!);
 
-    /// <summary>
-    /// Converts a standard tryer function (like int.TryParse, Dictionary.TryGetValue etc.) to a function, returning Maybe
-    /// </summary>
-    /// <typeparam name="TR"></typeparam>
-    /// <typeparam name="TK"></typeparam>
-    /// <param name="tryer"></param>
-    /// <returns></returns>
-    public static Func<TK, Maybe<TR>> WrapNrt<TK, TR>(TryGet<TK, TR?> tryer)  
-      where TR : notnull => (TK arg) => 
-      tryer(arg, out var result) ? result.ToMaybe() : Maybe<TR>.Nothing;
+		/// <summary>
+		/// Converts a standard tryer function (like int.TryParse, Dictionary.TryGetValue etc.) to a function, returning Maybe
+		/// </summary>
+		/// <typeparam name="TR"></typeparam>
+		/// <typeparam name="TK"></typeparam>
+		/// <param name="tryer"></param>
+		/// <returns></returns>
+		public static Func<TK, Maybe<TR>> WrapNrt<TK, TR>(TryGet<TK, TR?> tryer)  
+			where TR : notnull => (TK arg) => 
+			tryer(arg, out var result) ? result.ToMaybe() : Maybe<TR>.Nothing;
 
-    /// <summary>
-    /// Returns a function which calls <paramref name="f"/>, wrapped inside a try-catch clause with <typeparamref name="TEx"/> catched. 
-    /// That new function returns Nothing in the case of the <typeparamref name="TEx"/> thrown inside <paramref name="f"/>, otherwise it returns the f-result as Maybe
-    /// </summary>
-    /// <typeparam name="TA"></typeparam>
-    /// <typeparam name="TR"></typeparam>
-    /// <typeparam name="TEx"></typeparam>
-    /// <param name="f"></param>
-    /// <returns></returns>
-    public static Func<TA, Maybe<TR>> Catcher<TA, TR, TEx>(Func<TA, TR> f)
-      where TEx : Exception where TR : notnull => 
-      CatcherNrt<TA, TR, TEx>(f);
+		/// <summary>
+		/// Returns a function which calls <paramref name="f"/>, wrapped inside a try-catch clause with <typeparamref name="TEx"/> catched. 
+		/// That new function returns Nothing in the case of the <typeparamref name="TEx"/> thrown inside <paramref name="f"/>, otherwise it returns the f-result as Maybe
+		/// </summary>
+		/// <typeparam name="TA"></typeparam>
+		/// <typeparam name="TR"></typeparam>
+		/// <typeparam name="TEx"></typeparam>
+		/// <param name="f"></param>
+		/// <returns></returns>
+		public static Func<TA, Maybe<TR>> Catcher<TA, TR, TEx>(Func<TA, TR> f)
+			where TEx : Exception where TR : notnull => 
+			CatcherNrt<TA, TR, TEx>(f);
 
-    /// <summary>
-    /// Returns a function which calls <paramref name="f"/>, wrapped inside a try-catch clause with <typeparamref name="TEx"/> catched. 
-    /// That new function returns Nothing in the case of the <typeparamref name="TEx"/> thrown inside <paramref name="f"/>, otherwise it returns the f-result as Maybe
-    /// </summary>
-    /// <typeparam name="TA"></typeparam>
-    /// <typeparam name="TR"></typeparam>
-    /// <typeparam name="TEx"></typeparam>
-    /// <param name="f"></param>
-    /// <returns></returns>
-    public static Func<TA, Maybe<TR>> CatcherNrt<TA, TR, TEx>(Func<TA, TR?> f) 
-      where TEx : Exception where TR : notnull => (TA arg) =>
-    {
-      try
-      {
-        return f(arg).ToMaybe();
-      }
-      catch (TEx)
-      {
-        return default;
-      }
-    };
+		/// <summary>
+		/// Returns a function which calls <paramref name="f"/>, wrapped inside a try-catch clause with <typeparamref name="TEx"/> catched. 
+		/// That new function returns Nothing in the case of the <typeparamref name="TEx"/> thrown inside <paramref name="f"/>, otherwise it returns the f-result as Maybe
+		/// </summary>
+		/// <typeparam name="TA"></typeparam>
+		/// <typeparam name="TR"></typeparam>
+		/// <typeparam name="TEx"></typeparam>
+		/// <param name="f"></param>
+		/// <returns></returns>
+		public static Func<TA, Maybe<TR>> CatcherNrt<TA, TR, TEx>(Func<TA, TR?> f) 
+			where TEx : Exception where TR : notnull => (TA arg) =>
+		{
+			try
+			{
+				return f(arg).ToMaybe();
+			}
+			catch (TEx)
+			{
+				return default;
+			}
+		};
 
   }
 }

--- a/Functional.Maybe/MaybeLinq.cs
+++ b/Functional.Maybe/MaybeLinq.cs
@@ -16,7 +16,7 @@ namespace Functional.Maybe
 		/// <param name="fn"></param>
 		/// <returns></returns>
 		public static Maybe<TResult> Select<T, TResult>(this Maybe<T> a, Func<T, TResult?> fn) 
-      where T : notnull where TResult : notnull
+			where T : notnull where TResult : notnull
 		{
 			if (a.HasValue)
 			{
@@ -58,7 +58,7 @@ namespace Functional.Maybe
 		/// <param name="fn"></param>
 		/// <returns></returns>
 		public static Maybe<TR> SelectMany<T, TR>(this Maybe<T> a, Func<T, Maybe<TR>> fn) 
-      where T : notnull where TR : notnull => 
+			where T : notnull where TR : notnull => 
 			a.HasValue ? fn(a.Value) : default;
 
 		/// <summary>
@@ -100,7 +100,7 @@ namespace Functional.Maybe
 		/// <param name="composer"></param>
 		/// <returns></returns>
 		public static Maybe<TResult> SelectMaybe<T, TTempResult, TResult>(this Maybe<T> a, Func<T, Maybe<TTempResult>> fn, Func<T, TTempResult, TResult?> composer) 
-      where T : notnull where TResult : notnull where TTempResult : notnull =>
+			where T : notnull where TResult : notnull where TTempResult : notnull =>
 			a.SelectMany(fn, composer);
 	}
 }

--- a/Functional.Maybe/MaybeLinq.cs
+++ b/Functional.Maybe/MaybeLinq.cs
@@ -15,7 +15,8 @@ namespace Functional.Maybe
 		/// <param name="a"></param>
 		/// <param name="fn"></param>
 		/// <returns></returns>
-		public static Maybe<TResult> Select<T, TResult>(this Maybe<T> a, Func<T, TResult> fn)
+		public static Maybe<TResult> Select<T, TResult>(this Maybe<T> a, Func<T, TResult?> fn) 
+      where T : notnull where TResult : notnull
 		{
 			if (a.HasValue)
 			{
@@ -37,7 +38,7 @@ namespace Functional.Maybe
 		/// <param name="fn"></param>
 		/// <param name="else"></param>
 		/// <returns></returns>
-		public static TResult SelectOrElse<T, TResult>(this Maybe<T> a, Func<T, TResult> fn, Func<TResult> @else) => 
+		public static TResult SelectOrElse<T, TResult>(this Maybe<T> a, Func<T, TResult> fn, Func<TResult> @else) where T : notnull => 
 			a.HasValue ? fn(a.Value) : @else();
 		/// <summary>
 		/// If <paramref name="a"/> has value, and it fulfills the <paramref name="predicate"/>, returns <paramref name="a"/>, otherwise returns Nothing
@@ -46,7 +47,7 @@ namespace Functional.Maybe
 		/// <param name="a"></param>
 		/// <param name="predicate"></param>
 		/// <returns></returns>
-		public static Maybe<T> Where<T>(this Maybe<T> a, Func<T, bool> predicate) => 
+		public static Maybe<T> Where<T>(this Maybe<T> a, Func<T, bool> predicate) where T : notnull => 
 			a.HasValue && predicate(a.Value) ? a : default;
 		/// <summary>
 		/// If <paramref name="a"/> has value, applies <paramref name="fn"/> to it and returns, otherwise returns Nothing
@@ -56,7 +57,8 @@ namespace Functional.Maybe
 		/// <param name="a"></param>
 		/// <param name="fn"></param>
 		/// <returns></returns>
-		public static Maybe<TR> SelectMany<T, TR>(this Maybe<T> a, Func<T, Maybe<TR>> fn) => 
+		public static Maybe<TR> SelectMany<T, TR>(this Maybe<T> a, Func<T, Maybe<TR>> fn) 
+      where T : notnull where TR : notnull => 
 			a.HasValue ? fn(a.Value) : default;
 
 		/// <summary>
@@ -70,7 +72,8 @@ namespace Functional.Maybe
 		/// <param name="fn"></param>
 		/// <param name="composer"></param>
 		/// <returns></returns>
-		public static Maybe<TResult> SelectMany<T, TTempResult, TResult>(this Maybe<T> a, Func<T, Maybe<TTempResult>> fn, Func<T, TTempResult, TResult> composer) => 
+		public static Maybe<TResult> SelectMany<T, TTempResult, TResult>(this Maybe<T> a, Func<T, Maybe<TTempResult>> fn, Func<T, TTempResult, TResult?> composer) 
+			where T : notnull where TResult : notnull where TTempResult : notnull => 
 			a.SelectMany(x => fn(x).SelectMany(y => composer(x, y).ToMaybe()));
 
 		/// <summary>
@@ -81,7 +84,8 @@ namespace Functional.Maybe
 		/// <param name="a"></param>
 		/// <param name="fn"></param>
 		/// <returns></returns>
-		public static Maybe<TR> SelectMaybe<T, TR>(this Maybe<T> a, Func<T, Maybe<TR>> fn) =>
+		public static Maybe<TR> SelectMaybe<T, TR>(this Maybe<T> a, Func<T, Maybe<TR>> fn) 
+			where T : notnull where TR : notnull =>
 			a.SelectMany(fn);
 
 		/// <summary>
@@ -95,7 +99,8 @@ namespace Functional.Maybe
 		/// <param name="fn"></param>
 		/// <param name="composer"></param>
 		/// <returns></returns>
-		public static Maybe<TResult> SelectMaybe<T, TTempResult, TResult>(this Maybe<T> a, Func<T, Maybe<TTempResult>> fn, Func<T, TTempResult, TResult> composer) =>
+		public static Maybe<TResult> SelectMaybe<T, TTempResult, TResult>(this Maybe<T> a, Func<T, Maybe<TTempResult>> fn, Func<T, TTempResult, TResult?> composer) 
+      where T : notnull where TResult : notnull where TTempResult : notnull =>
 			a.SelectMany(fn, composer);
 	}
 }

--- a/Functional.Maybe/MaybeReturns.cs
+++ b/Functional.Maybe/MaybeReturns.cs
@@ -14,7 +14,7 @@ namespace Functional.Maybe
 		/// <param name="a"></param>
 		/// <param name="default"></param>
 		/// <returns></returns>
-		public static string ReturnToString<T>(this Maybe<T> a, string @default)
+		public static string ReturnToString<T>(this Maybe<T> a, string @default) where T : notnull
 		{
 			return a.HasValue ? a.Value.ToString() : @default;
 		}
@@ -26,7 +26,8 @@ namespace Functional.Maybe
 		/// <param name="a"></param>
 		/// <param name="e"></param>
 		/// <returns></returns>
-		public static T OrElse<T>(this Maybe<T> a, Func<Exception> e)
+		public static T OrElse<T>(this Maybe<T> a, Func<Exception> e)  
+			where T : notnull
 		{
 			if (a.IsNothing())
 			{
@@ -39,10 +40,12 @@ namespace Functional.Maybe
 		/// Returns <paramref name="a"/>.Value or returns <paramref name="default"/>()
 		/// </summary>
 		/// <typeparam name="T"></typeparam>
+		/// <typeparam name="TResult"></typeparam>
 		/// <param name="a"></param>
 		/// <param name="default"></param>
 		/// <returns></returns>
-		public static T OrElse<T>(this Maybe<T> a, Func<T> @default) =>
+		public static TResult OrElse<T, TResult>(this Maybe<T> a, Func<TResult> @default)  
+			where T : notnull, TResult =>
 			a.HasValue ? a.Value : @default();
 
 		/// <summary>
@@ -51,17 +54,19 @@ namespace Functional.Maybe
 		/// <typeparam name="T"></typeparam>
 		/// <param name="a"></param>
 		/// <returns></returns>
-		public static T OrElseDefault<T>(this Maybe<T> a) =>
+		public static T? OrElseDefault<T>(this Maybe<T> a) where T : notnull =>
 			a.HasValue ? a.Value : default;
 
 		/// <summary>
 		/// Returns <paramref name="a"/>.Value or returns <paramref name="default"/>
 		/// </summary>
 		/// <typeparam name="T"></typeparam>
+		/// <typeparam name="TResult"></typeparam>
 		/// <param name="a"></param>
 		/// <param name="default"></param>
 		/// <returns></returns>
-		public static T OrElse<T>(this Maybe<T> a, T @default) =>
+		public static TResult OrElse<T, TResult>(this Maybe<T> a, TResult @default) 
+			where T : notnull, TResult =>
 			a.HasValue ? a.Value : @default;
 	}
 }

--- a/Functional.Maybe/MaybeSideEffects.cs
+++ b/Functional.Maybe/MaybeSideEffects.cs
@@ -14,7 +14,7 @@ namespace Functional.Maybe
 		/// <param name="m"></param>
 		/// <param name="fn"></param>
 		/// <returns></returns>
-		public static Maybe<T> Do<T>(this Maybe<T> m, Action<T> fn)
+		public static Maybe<T> Do<T>(this Maybe<T> m, Action<T> fn) where T : notnull
 		{
 			if (m.IsSomething())
 				fn(m.Value);
@@ -29,7 +29,7 @@ namespace Functional.Maybe
 		/// <param name="fn"></param>
 		/// <param name="else"></param>
 		/// <returns></returns>
-		public static Maybe<T> Match<T>(this Maybe<T> m, Action<T> fn, Action @else)
+		public static Maybe<T> Match<T>(this Maybe<T> m, Action<T> fn, Action @else) where T : notnull
 		{
 			if (m.IsSomething())
 				fn(m.Value);

--- a/Functional.Maybe/MaybeSomethingNothingHelpers.cs
+++ b/Functional.Maybe/MaybeSomethingNothingHelpers.cs
@@ -41,6 +41,6 @@ namespace Functional.Maybe
 		/// <param name="_"></param>
 		/// <returns></returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Maybe<T> NothingOf<T>(this T _) where T : notnull => default;
+		public static Maybe<T> NothingOf<T>(this T? _) where T : notnull => default;
 	}
 }

--- a/Functional.Maybe/MaybeSomethingNothingHelpers.cs
+++ b/Functional.Maybe/MaybeSomethingNothingHelpers.cs
@@ -14,7 +14,7 @@ namespace Functional.Maybe
 		/// <param name="a"></param>
 		/// <returns></returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static bool IsSomething<T>(this Maybe<T> a) => a.HasValue;
+		public static bool IsSomething<T>(this Maybe<T> a) where T : notnull => a.HasValue;
 
 		/// <summary>
 		/// Has no value inside
@@ -23,7 +23,7 @@ namespace Functional.Maybe
 		/// <param name="a"></param>
 		/// <returns></returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static bool IsNothing<T>(this Maybe<T> a) => !a.IsSomething();
+		public static bool IsNothing<T>(this Maybe<T> a) where T : notnull => !a.IsSomething();
 
 		/// <summary>
 		/// Создает "ничто" такого же типа, как исходный объект
@@ -32,7 +32,7 @@ namespace Functional.Maybe
 		/// <param name="_"></param>
 		/// <returns></returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Maybe<T> NothingOf<T>(this Maybe<T> _) => default;
+		public static Maybe<T> NothingOf<T>(this Maybe<T> _) where T : notnull => default;
 
 		/// <summary>
 		/// Создает "ничто" такого же типа, как исходный объект
@@ -41,6 +41,6 @@ namespace Functional.Maybe
 		/// <param name="_"></param>
 		/// <returns></returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Maybe<T> NothingOf<T>(this T _) => default;
+		public static Maybe<T> NothingOf<T>(this T _) where T : notnull => default;
 	}
 }


### PR DESCRIPTION
Hi, 

This is a PR that does, as I understand it, a complete handling of NRTs in Functional.Maybe. I closed the earlier PR thinking there is a better way to do it, but I now believe that for the principles I adopted, there isn't one.

The principles for the feature design that I adopted are:

1. `T` in `Maybe<T>` is `notnull`, otherwise users could create `Maybe<string?>`, which:
  * wouldn't make sense as Maybe is a replacement for `null`, not a container around it,
  * wouldn lead to "possible null" warnings when invoking `.Value` on such a maybe (which is especially problematic in generic code, which doesn't know if e.g. `Maybe<T>` is a `Maybe<string>` or a `Maybe<string?>`).
2. User should never have to suppress nullability warnings when invoking normal API features
  * I consider suppressing NRT warnings a workaround, so IMO an API should not rely on it because the reader will later have difficulties between telling valid API usage from nasty workaround.

These two points led to changes some of which can be considered controversial:

1. Many methods needed to be annotated with `notnull`. This is only a breaking change if someone has enabled NRT analysis and treats nullable warnings as errors. 
2. In some methods, I added another generic parameter e.g. on OrElse, which is now `TResult OrElse<T, TResult>(this Maybe<T> a, Func<TResult> @default) where T : notnull, TResult`. This is because when done this way, a single method can handle both NRTs and non-NRTs. This is a breaking change, but only if someone explicitly specified the generic parameters, which, IMO, should be a rare case.
3. In other methods, like `Lookup`, a single method could not handle both NRTs and non-NRTs. Going further with the example of `Lookup`, I couldn't find a way (and I'd argue it doesn't exist) to pass both `Dictionary<string, string>` and `Dictionary<string, string?>` to the same method without warnings. This is because the following code gives warnings: `Dictionary<string, string?> d = new Dictionary<string, string>()`. In these cases, I really had no choice but to create two methods, one for `Dictionary<string, string>` and one for `Dictionary<string, string?>`. In cases like this one, I decided to name the "more NRT-friendly" version with a "Nrt" suffix as I assumed that the "non-NRT" versions will be used more often. These additional methods aren't what I wanted to end up with, but I see no other way - overloads don't work in this case, because `T` and `T?` aren't different types. There are total of 6 methods that required this kind of addition and I regret that I couldn't do it another way (though I tried, see https://stackoverflow.com/questions/68551157/c-sharp-nullable-reference-types-can-this-function-accept-a-dictionary-with-bot and https://twitter.com/GGalezowski/status/1420108618536472577).

I welcome feedback if you don't like the design decisions I made for this PR.

I also added some unit tests around the areas where I wasn't sure how they will work with NRTs. This isn't by any means a complete coverage, just the cases I needed to get the feedback while modifying the code. Also, I did not know which naming convention to follow for the test cases, so I kind of guessed. Any feedback is welcome. My incertainty about conventions applies to indentation as well. I didn't know which to follow as there are multiple conventions in use, sometimes even in a single file. Again, let me know what you prefer and I am ready to change it.

By the way, apologies for the size of this PR. I could not find a way to make it smaller.
